### PR TITLE
Fixed typo

### DIFF
--- a/core/standard/requirements/core/REQ_rc-sortby-definition.adoc
+++ b/core/standard/requirements/core/REQ_rc-sortby-definition.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/rc-sortby-definition*
-^|A |The operation SHALL support a parameter `sorby` with the following characteristics (using an OpenAPI Specification 3.0 fragment):
+^|A |The operation SHALL support a parameter `sortby` with the following characteristics (using an OpenAPI Specification 3.0 fragment):
 
 [source,YAML]
 -----


### PR DESCRIPTION
From 'sorby' to 'sortby'