### PR TITLE
fix reference to extent

### DIFF
--- a/core/openapi/ogcapi-records-1.yaml
+++ b/core/openapi/ogcapi-records-1.yaml
@@ -524,7 +524,7 @@ components:
                 A statement that concerns all rights not addresses by the
                 license such as a copyright statement.
             extent:
-              $ref: ./extent.yaml
+              $ref: "#/components/schemas/extent"
             associations:
               type: array
               description: |-


### PR DESCRIPTION
Fixes ref error for extent.  Note that I'm not sure how the resulting `core/openapi/ogcapi-records-1.yaml` is generated (would be good to have a `README` in `core/openapi` to this effect), so the issue may or may not be deeper in the schemas which generate `core/openapi/ogcapi-records-1.yaml`.