### PR TITLE
Editorial updates 2021-06-17

### DIFF
--- a/OGC_API_Catalogues_SWG_Charter.adoc
+++ b/OGC_API_Catalogues_SWG_Charter.adoc
@@ -166,7 +166,7 @@ Each of these documents recommends an emphasis on resource oriented APIs in futu
 
 In addition, the following metadata standards will be reviewed:
 
-   * Earth Observation Process and Application Discovery (https://portal.opengeospatial.org/files/?artifact_id=82290#EOPAD)
+   * Earth Observation Process and Application Discovery (https://portal.ogc.org/files/?artifact_id=82290#EOPAD)
 
    * OGC OpenSearch Extension for Earth Observation, OGC 13-026r8;
 
@@ -188,9 +188,9 @@ In addition, the following metadata standards will be reviewed:
 
    * ISO 19135-1:2015: Geographic information -- Procedures for item registration -- Part 1: Fundamentals
 
-   * CDB SWG Metadata Analysis Spreadsheet (https://portal.opengeospatial.org/files/?artifact_id=73769)
+   * CDB SWG Metadata Analysis Spreadsheet (https://portal.ogc.org/files/?artifact_id=73769)
 
-   * DRAFT OGC CDB Metadata Enhancements: Background and Recommendations (https://portal.opengeospatial.org/files/?artifact_id=73767)
+   * DRAFT OGC CDB Metadata Enhancements: Background and Recommendations (https://portal.ogc.org/files/?artifact_id=73767)
 
    * Security in your OpenAPI Specification (https://hackernoon.com/security-in-your-openapi-specification-94d081603950)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Lists all the metadata records that describe objects in the New Zealand economic
 
 The response format is determined using standard [HTTP content negotiation](https://restfulapi.net/content-negotiation/).
 
-Data is returned in pageable chunks, with each response containing a `next` link pointing to the next set of response records.  The core specification supports a basic set of filters roughly analogous to the [OpenSearch](https://opensearch.org) and OGC OpenSearch Geo (https://portal.opengeospatial.org/files/?artifact_id=56866) query parameters.
+Data is returned in pageable chunks, with each response containing a `next` link pointing to the next set of response records.  The core specification supports a basic set of filters roughly analogous to the [OpenSearch](https://opensearch.org) and OGC OpenSearch Geo (https://portal.ogc.org/files/?artifact_id=56866) query parameters.
 
 ```
 GET /collections/myCatalogue/items/{recordId}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 OGC API - Records provides discovery and access to metadata about geospatial data and services.
 
-[OGC API standards](https://ogcapi.ogc.org) define modular API building blocks to spatially enable Web APIs in a consistent way. [OpenAPI](http://openapis.org) is used to define the reusable API building blocks.
+[OGC API standards](https://ogcapi.ogc.org) define modular API building blocks to spatially enable Web APIs in a consistent way. [OpenAPI](https://openapis.org) is used to define the reusable API building blocks.
 
 ```
 GET /collections/myCatalogue/items

--- a/core/examples/json/landingPage.json
+++ b/core/examples/json/landingPage.json
@@ -1,31 +1,31 @@
 {
     "links": [
         {
-            "href": "http://data.example.org/",
+            "href": "https://example.org/",
             "rel": "self",
             "type": "application/json",
             "title": "This Document"
         },
         {
-            "href": "http://data.example.org/api",
+            "href": "https://example.org/api",
             "rel": "service-desc",
             "type": "application/openapi+json;version=3.0",
             "title": "The API Definition"
         },
         {
-            "href": "http://data.example.org/api",
+            "href": "https://example.org/api",
             "rel": "service-doc",
             "type": "text/html",
             "title": "The API Document"
         },
         {
-            "href": "http://data.example.org/conformance",
+            "href": "https://example.org/conformance",
             "rel": "conformance",
             "type": "application/json",
             "title": "OGC Conformance Classes Implemented by this API"
         },
         {
-            "href": "http://data.example.org/collections",
+            "href": "https://example.org/collections",
             "rel": "data",
             "type": "application/json",
             "title": "Metadata About the Resource Collections"

--- a/core/examples/json/record-collection.json
+++ b/core/examples/json/record-collection.json
@@ -13,59 +13,59 @@
   ],
   "links": [
     {
-       "href": "http://www.someserver.com/collections/myCatalogue?f=json...",
+       "href": "https://example.org/collections/myCatalogue?f=json...",
        "rel": "collection",
        "type": "application/geo+json",
-       "title": "Link to the containing collection in JSON."
+       "title": "Link to the containing collection in JSON"
     },
     {
-       "href": "http://www.someserver.com/collections/myCatalogue?f=html...",
+       "href": "https://example.org/collections/myCatalogue?f=html...",
        "rel": "collection",
        "type": "text/html",
-       "title": "Link to the containing collection in HTML."
+       "title": "Link to the containing collection in HTML"
     },
     {
-       "href": "http://www.someserver.com/collections/myCatalogue?f=xml...",
+       "href": "https://example.org/collections/myCatalogue?f=xml...",
        "rel": "collection",
        "type": "text/xml",
-       "title": "Link to the containing collection in XML."
+       "title": "Link to the containing collection in XML"
     },
 
     {
-       "href": "http://www.someserver.com/collections/myCatalogue/items?f=json&...",
+       "href": "https://example.org/collections/myCatalogue/items?f=json&...",
        "rel": "self",
        "type": "application/geo+json",
-       "title": "Link to this response."
+       "title": "Link to this response"
     },
     {
-       "href": "http://www.someserver.com/collections/myCatalogue/items?f=html&...",
+       "href": "https://example.org/collections/myCatalogue/items?f=html&...",
        "rel": "alternate",
        "type": "text/html",
-       "title": "Link to this response in HTML."
+       "title": "Link to this response in HTML"
     },
     {
-       "href": "http://www.someserver.com/collections/myCatalogue/items?f=atom&...",
+       "href": "https://example.org/collections/myCatalogue/items?f=atom&...",
        "rel": "alternate",
        "type": "application/atom+xml",
-       "title": "Link to this response in ATOM (i.e. as an ATOM feed)."
+       "title": "Link to this response in ATOM (i.e. as an ATOM feed)"
     },
     {
-       "href": "http://www.someserver.com/collections/myCatalogue/items?f=json&startIndex=20&limit=10...",
+       "href": "https://example.org/collections/myCatalogue/items?f=json&startIndex=20&limit=10...",
        "rel": "next",
        "type": "application/geo+json",
-       "title": "Link to the next set of records in GeoJSON."
+       "title": "Link to the next set of records in GeoJSON"
     },
     {
-       "href": "http://www.someserver.com/collections/myCatalogue/items?f=html&startIndex=20&limit=10...",
+       "href": "https://example.org/collections/myCatalogue/items?f=html&startIndex=20&limit=10...",
        "rel": "next",
        "type": "text/html",
-       "title": "Link to the next set of records in HTML."
+       "title": "Link to the next set of records in HTML"
     },
     {
-       "href": "http://www.someserver.com/collections/myCatalogue/items?f=atom&startIndex=20&limit=10...",
+       "href": "https://example.org/collections/myCatalogue/items?f=atom&startIndex=20&limit=10...",
        "rel": "next",
        "type": "application/atom+xml",
-       "title": "Link to the next set of records in ATOM (i.e. as an ATOM feed)."
+       "title": "Link to the next set of records in ATOM (i.e. as an ATOM feed)"
     }
   ]
 }

--- a/core/examples/json/record.json
+++ b/core/examples/json/record.json
@@ -137,7 +137,7 @@
                 "title": "OGC Web Feature Service (WFS)",
                 "href": "https://geo.woudc.org/ows"
             }
-        ],
+        ]
     },
     "links": [
       {

--- a/core/examples/yaml/ogcapi-record-1-example1.yaml
+++ b/core/examples/yaml/ogcapi-record-1-example1.yaml
@@ -18,14 +18,14 @@ info:
   contact:
     name: CubeWerx Inc.
     email: pvretano@cubewerx.com
-    url: 'http://www.cubewerx.com'
+    url: 'https://www.cubewerx.com'
   license:
     name: CC-BY 4.0 license
     url: 'https://creativecommons.org/licenses/by/4.0/'
 servers:
-  - url: 'https://data.example.org/'
+  - url: 'https://example.org/data'
     description: Production server
-  - url: 'https://dev.example.org/'
+  - url: 'https://example.org/data-dev'
     description: Development server
 tags:
   - name: Capabilities

--- a/core/openapi/ogcapi-records-1.yaml
+++ b/core/openapi/ogcapi-records-1.yaml
@@ -478,7 +478,7 @@ components:
               description: |-
                  Link to the entity making the resource available. Recommended
                  best practice is to use a VCard
-                 (see http://www.w3.org/TR/vcard-rdf/).
+                 (see https://www.w3.org/TR/vcard-rdf/).
               format: uri
             themes:
               type: array
@@ -511,7 +511,7 @@ components:
               description: |-
                  Link to relevant contact information.  Recommended best
                  practice is to use a VCard
-                 (see http://www.w3.org/TR/vcard-rdf/).
+                 (see https://www.w3.org/TR/vcard-rdf/).
               format: uri
             license:
               type: string

--- a/core/openapi/ogcapi-records-1.yaml
+++ b/core/openapi/ogcapi-records-1.yaml
@@ -9,7 +9,7 @@ info:
     OGC API - Records - Part 1: Core 1.0 is an OGC Standard.
     Copyright (c) 2020 Open Geospatial Consortium.
     To obtain additional rights of use, visit
-    http://www.opengeospatial.org/legal/ .
+    https://www.ogc.org/legal/ .
 
     This document is also available on
     [OGC](http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/ogcapi-records-1.yaml).
@@ -19,7 +19,7 @@ info:
     email: pvretano@pvretano.com
   license:
     name: OGC License
-    url: 'http://www.opengeospatial.org/legal/'
+    url: 'https://www.ogc.org/legal/'
 components:
   parameters:
     bbox:

--- a/core/openapi/schemas/responsibleParty.yaml
+++ b/core/openapi/schemas/responsibleParty.yaml
@@ -2,7 +2,7 @@ oneOf:
   - type: string
     description: |-
       A reference to information about the responsible party.  For example,
-      a link to a VCard (see http://www.w3.org/TR/vcard-rdf/).
+      a link to a VCard (see https://www.w3.org/TR/vcard-rdf/).
     format: url
   - type: object
     description: |-

--- a/core/standard/20-004.adoc
+++ b/core/standard/20-004.adoc
@@ -27,8 +27,8 @@
 |Publication Date: 2020-01-13
 |External identifier of this OGC(R) document: http://www.opengis.net/doc/is/ogcapi-records-1/1.0
 |Internal reference number of this OGC(R) document: 20-004
-|Version: 0.0.1
-|Category: OGC(R) Implementation Specification
+|Version: 1.0.0-draft.1
+|Category: OGC(R) Implementation Standard
 |Editors:  Panagiotis (Peter) A. Vretanos, Tom Kralidis, Charles Heazel
 |===
 
@@ -54,7 +54,8 @@ Recipients of this document are invited to submit, with their comments, notifica
 
 [width = "50%", grid = "none"]
 |===
-|Document type: OGC(R) Implementation Specification
+|Document type: OGC(R) Standard
+|Document subtype: Interface
 |Document stage: Draft
 |Document language: English
 |===

--- a/core/standard/20-004.adoc
+++ b/core/standard/20-004.adoc
@@ -41,7 +41,7 @@
 |===
 |*Copyright notice*
 |Copyright (C) 2020 Open Geospatial Consortium
-|To obtain additional rights of use, visit http://www.opengeospatial.org/legal/
+|To obtain additional rights of use, visit https://www.ogc.org/legal/
 |===
 
 [cols = "^", frame = "none"]

--- a/core/standard/README.md
+++ b/core/standard/README.md
@@ -9,7 +9,7 @@ This specification addresses only those parts of an API which are specific to Re
 
 The latest drafts of each standard in this repository are built daily (based on the configuration contained in the [asciidoctor.json](https://github.com/opengeospatial/ogcapi-records/blob/master/asciidoctor.json) file):
 
-* [Part 1: Core](http://docs.ogc.org/DRAFTS/20-004.html)
+* [Part 1: Core](https://docs.ogc.org/DRAFTS/20-004.html)
 
 To generate HTML and PDF representations of the standard yourself, asciidoctor is required.  To install:
 

--- a/core/standard/annex_history.adoc
+++ b/core/standard/annex_history.adoc
@@ -7,4 +7,5 @@
 |Date |Release |Editor | Primary clauses modified |Description
 |2020-01-13 |Template |C. Heazel |all |initial template
 |2020-04-22 |1.0-dev |T. Kralidis |all|changes to reflect Records, editorial updates, add Q parameter to clause 7
+|2021-06-18 |1.0-dev |T. Kralidis |all|full review for 1.0.0-draft.1
 |===

--- a/core/standard/clause_0_front_material.adoc
+++ b/core/standard/clause_0_front_material.adoc
@@ -2,7 +2,7 @@
 
 The OGC API family of standards are being developed to make it easy for anyone to provide geospatial data to the web. These standards build upon the legacy of the OGC Web Service standards (WMS, WFS, WCS, WPS, etc.), but define resource-centric APIs that take advantage of modern web development practices. 
 
-This document defines the OGC API for Records. A Record is a way of making a resource discoverable. In this context, resources are things that would be useful to a user or developer, such as features, coverages, tiles / maps, assets, services or widgets. The OGC API - Records provides a way to query or browse a curated set of Records known as a catalogue. 
+This document defines the OGC API for Records. A Record is a way of making a resource discoverable. In this context, resources are things that would be useful to a user or developer, such as features, coverages, tiles / maps, assets, services or widgets. OGC API - Records provides a way to query or browse a curated set of Records known as a catalogue. 
 
 [reftext='{table-caption} {counter:table-num}']
 .Overview of resources, applicable HTTP methods and links to the document sections[[table_1]][[tldnr]]
@@ -17,28 +17,29 @@ This document defines the OGC API for Records. A Record is a way of making a res
 |Record |`/collections/{collectionId}/items/{recordId}` |GET |<<record-access,Record Access>>
 |===
 
+[[keywords]]
 [big]*ii.    Keywords*
 
 The following are keywords to be used by search engines and document catalogues.
 
-ogcdoc, OGC document, OGC API, catalogue, record, resource
+ogcdoc, OGC document, OGC API, catalogue, record, records, resource, metadata, discovery, CSW, API, GeoJSON, HTML, schema.org, JSON-LD
 
+[[preface]]
 [big]*iii.   Preface*
 
-[NOTE]
-====
-Insert Preface Text here. Give OGC specific commentary: describe the technical content, reason for document, history of the document and precursors, and plans for future work. >
-Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium shall not be held responsible for identifying any or all such patent rights.
+*OGC Declaration*
+
+Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. The Open Geospatial Consortium Inc. shall not be held responsible for identifying any or all such patent rights.
 
 Recipients of this document are requested to submit, with their comments, notification of any relevant patent claims or other intellectual property rights of which they may be aware that might be infringed by any implementation of the standard set forth in this document, and to provide supporting documentation.
-====
+
+[[submitting_organizations]]
 [big]*iv.    Submitting organizations*
 
 The following organizations submitted this Document to the Open Geospatial Consortium (OGC):
 
-Organization name(s)
-
 * CubeWerx Inc.
+* Meteorological Service of Canada
 
 [big]*v.     Submitters*
 

--- a/core/standard/clause_10_record-filter.adoc
+++ b/core/standard/clause_10_record-filter.adoc
@@ -1,12 +1,12 @@
 [[clause-record-filter]]
-== Requirements Class "CQL Filter"
+== Requirements Class "Filtering using the Common Query Language (CQL)"
 
 [[record-filter-overview]]
 === Overview
 
 include::requirements/requirements_class_record-filter.adoc[]
 
-This clause defines the binding to the filter parameters defined in the https://docs.ogc.org/DRAFTS/19-079.html#_requirements_class_filter[OGC API - Features - Part 3: Filter and the Common Query Language (CQL), Requirements Class "Filter"] clause.
+This clause defines the binding to the filter parameters defined in the https://docs.ogc.org/DRAFTS/19-079.html#_requirements_class_filter[OGC API - Features - Part 3: Filtering and the Common Query Language (CQL), Requirements Class "Filter"] clause.
 
 === Records
 

--- a/core/standard/clause_10_record-filter.adoc
+++ b/core/standard/clause_10_record-filter.adoc
@@ -77,12 +77,12 @@ The following examples illustrate each of these linking patterns:
          {
             "rel" : "alternate",
             "title" : "This records as XML.",
-            "href" : "https://example.com/collections/MyCat/items/rec01.xml"
+            "href" : "https://example.org/collections/mycat/items/rec01.xml"
          },
          {
             "rel": "next",
             "title": "The next record in this result set.",
-            "href" : "https://example.com/collections/MyCat/items/rec02"
+            "href" : "https://example.org/collections/mycat/items/rec02"
          },
          .
          .
@@ -114,7 +114,7 @@ The following examples illustrate each of these linking patterns:
          {
             "rel" : "related",
             "title" : "A related record.",
-            "href" : "https://example.com/collections/YourCat/items/rec15"
+            "href" : "https://example.org/collections/yourcat/items/rec15"
          },
          {
             "rel": "license",
@@ -147,7 +147,7 @@ The following examples illustrate each of these linking patterns:
       "related": [
          {
 		      "title" : "A related record",
-		      "href" : "https://example.com/related-record-path/rec15"
+		      "href" : "https://example.org/related-record-path/rec15"
 	      }
       ],
       "license": {
@@ -173,7 +173,7 @@ The following examples illustrate each of these linking patterns:
       .
       .,
 
-      "related": ["https://example.com/related-record-path/rec15"],
+      "related": ["https://example.org/related-record-path/rec15"],
       "license": "https://creativecommons.org/licenses/by/2.0/",
       .
       .

--- a/core/standard/clause_10_record-filter.adoc
+++ b/core/standard/clause_10_record-filter.adoc
@@ -6,13 +6,13 @@
 
 include::requirements/requirements_class_record-filter.adoc[]
 
-This clause defines the binding to the filter parameters defined in the http://docs.opengeospatial.org/DRAFTS/19-079.html#_requirements_class_filter[OGC API - Features - Part 3: Filter and the Common Query Language (CQL), Requirements Class "Filter"] clause.
+This clause defines the binding to the filter parameters defined in the https://docs.ogc.org/DRAFTS/19-079.html#_requirements_class_filter[OGC API - Features - Part 3: Filter and the Common Query Language (CQL), Requirements Class "Filter"] clause.
 
 === Records
 
 ==== Operation
 
-As specified in the <<records-access,Records Access>> clause, records are accessed using the HTTP GET method via the `/collections/{collectionId}/items` path.  The following additional requirements bind the parameters http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-param[filter], http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-lang-param[filter-lang] and http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-filter-crs[filter-crs] to the GET operation on this path.
+As specified in the <<records-access,Records Access>> clause, records are accessed using the HTTP GET method via the `/collections/{collectionId}/items` path.  The following additional requirements bind the parameters https://docs.ogc.org/DRAFTS/19-079.html#filter-param[filter], https://docs.ogc.org/DRAFTS/19-079.html#filter-lang-param[filter-lang] and https://docs.ogc.org/DRAFTS/19-079.html#filter-filter-crs[filter-crs] to the GET operation on this path.
 
 include::requirements/record-filter/REQ_filter-param.adoc[]
 
@@ -47,7 +47,7 @@ Links can be added to the following sections in a catalogue record:
 . the <<query-response,associations>> section.
 . the <<query-response,properties>> section.
 
-The schema for links added to the <<query-response,links>> and <<query-response,associations>> sections in based on https://tools.ietf.org/html/rfc8288[RFC 8288] and is described in http://docs.opengeospatial.org/DRAFTS/19-072.html#link-relation-conventions[OGC API - Common - Part 1: Core] and http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml[OGC API - Features - Part 1: Core].
+The schema for links added to the <<query-response,links>> and <<query-response,associations>> sections in based on https://tools.ietf.org/html/rfc8288[RFC 8288] and is described in https://docs.ogc.org/DRAFTS/19-072.html#link-relation-conventions[OGC API - Common - Part 1: Core] and http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml[OGC API - Features - Part 1: Core].
 
 Links added directly to the <<query-response,properties>> section of a catalogue record can be
 added using the following patterns:

--- a/core/standard/clause_11_opensearch.adoc
+++ b/core/standard/clause_11_opensearch.adoc
@@ -38,60 +38,60 @@ include::requirements/opensearch/REQ_descriptiondoc-response-outputenc.adoc[]
 [source, json]
 =====
  Client                                                                   Server
-   |                                                                         |
-   |   GET /api       HTTP/1.1                                               |
-   |   Accept: application/opensearchdescription+xml                         |
-   |------------------------------------------------------------------------>|
-   |                                                                         |
-   |   HTTP/1.1 204 OK                                                       |
-   |   Content-Type: application/opensearchdescription+xml                   |
-   |                                                                         |
-   |   <?xml version="1.0" encoding="UTF-8"?>                                |
-   |   <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">  |
-   |      <ShortName>OGC API Records Search</ShortName>                      |
-   |      <Description>Resource discovery using the OpenSearch interface of  |
-   |                   OGC API Records - Part 1: Core</Description>          |
-   |      <Tags>OGC API Records search resource discovery</Tags>             |
-   |      <Contact>admin@example.com</Contact>                               |
-   |      <Url rel="collection"                                              |
-   |           template="http://example.com/collections/mycatalog"/>         |
-   |      <Url rel="self"                                                    |
-   |           type="application/opensearchdescription+xml"                  |
-   |           template="http://example.com/api?f=osdescd"/>                 |
-   |      <Url rel="results"                                                 |
-   |           type="application/atom+xml"                                   |
-   |           template="http://example.com/oapir/collections/mycatalog/items?
-   |           bbox={geo:box}&amp;datetime={time:start}/{time:end}&amp;      |
-   |           limit={count}&amp;offset={startIndex}&amp;q={searchTerms}&amp;|
-   |           f=atom"/>                                                     |
-   |      <Url rel="results"                                                 |
-   |           type="application/geo+json"                                   |
-   |           template="http://example.com/oapir/collections/mycatalog/items?
-   |           bbox={geo:box}&amp;datetime={time:start}/{time:end}&amp;      |
-   |           limit={count}&amp;offset={startIndex}&amp;q={searchTerms}&amp;|
-   |           f=json>                                                       |
-   |      <Url rel="results"                                                 |
-   |           type="text/html"                                              |
-   |           template="http://example.com/oapir/collections/mycatalog/items?
-   |           bbox={geo:box}&amp;datetime={time:start}/{time:end}&amp;      |
-   |           limit={count}&amp;offset={startIndex}&amp;q={searchTerms}&amp;|
-   |           f=html"/>                                                     |
-   |      <Query role="example" searchTerms="dataset"/>                      |
-   |      <LongName>OGC API Records Search</LongName>                        |
-   |      <Image height="64" width="64" type="image/png">                    |
-   |         http://example.com/websearch.png</Image>                        |
-   |      <Image height="16" width="16" type="image/vnd.microsoft.icon">     |
-   |         http://example.com/websearch.ico</Image>                        |
-   |      <Developer>OGC</Developer>                                         |
-   |      <Attribution>Search data Copyright 2021, Example.com, Inc.,        |
-   |                   All Rights Reserved</Attribution>                     |
-   |      <SyndicationRight>open</SyndicationRight>                          |
-   |      <AdultContent>false</AdultContent>                                 |
-   |      <Language>en-us</Language>                                         |
-   |      <OutputEncoding>UTF-8</OutputEncoding>                             |
-   |      <InputEncoding>UTF-8</InputEncoding>                               |
-   |   </OpenSearchDescription>                                              |
-   |<------------------------------------------------------------------------|
+   |                                                                            |
+   |   GET /api       HTTP/1.1                                                  |
+   |   Accept: application/opensearchdescription+xml                            |
+   |--------------------------------------------------------------------------->|
+   |                                                                            |
+   |   HTTP/1.1 204 OK                                                          |
+   |   Content-Type: application/opensearchdescription+xml                      |
+   |                                                                            |
+   |   <?xml version="1.0" encoding="UTF-8"?>                                   |
+   |   <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">     |
+   |      <ShortName>OGC API - Records Search</ShortName>                       |
+   |      <Description>Resource discovery using the OpenSearch interface of     |
+   |                   OGC API - Records - Part 1: Core</Description>           |
+   |      <Tags>OGC API - Records search resource discovery</Tags>              |
+   |      <Contact>admin@example.com</Contact>                                  |
+   |      <Url rel="collection"                                                 |
+   |           template="https://example.org/collections/mycatalog"/>           |
+   |      <Url rel="self"                                                       |
+   |           type="application/opensearchdescription+xml"                     |
+   |           template="https://example.org/api?f=osdescd"/>                   |
+   |      <Url rel="results"                                                    |
+   |           type="application/atom+xml"                                      |
+   |           template="https://example.org/oapir/collections/mycatalog/items?
+   |           bbox={geo:box}&amp;datetime={time:start}/{time:end}&amp;         |
+   |           limit={count}&amp;offset={startIndex}&amp;q={searchTerms}&amp;   |
+   |           f=atom"/>                                                        |
+   |      <Url rel="results"                                                    |
+   |           type="application/geo+json"                                      |
+   |           template="https://example.org/oapir/collections/mycatalog/items?
+   |           bbox={geo:box}&amp;datetime={time:start}/{time:end}&amp;         |
+   |           limit={count}&amp;offset={startIndex}&amp;q={searchTerms}&amp;   |
+   |           f=json>                                                          |
+   |      <Url rel="results"                                                    |
+   |           type="text/html"                                                 |
+   |           template="https://example.org/oapir/collections/mycatalog/items?
+   |           bbox={geo:box}&amp;datetime={time:start}/{time:end}&amp;         |
+   |           limit={count}&amp;offset={startIndex}&amp;q={searchTerms}&amp;   |
+   |           f=html"/>                                                        |
+   |      <Query role="example" searchTerms="dataset"/>                         |
+   |      <LongName>OGC API - Records Search</LongName>                         |
+   |      <Image height="64" width="64" type="image/png">                       |
+   |         https://example.org/websearch.png</Image>                          |
+   |      <Image height="16" width="16" type="image/vnd.microsoft.icon">        |
+   |         https://example.org/websearch.ico</Image>                          |
+   |      <Developer>OGC</Developer>                                            |
+   |      <Attribution>Search data Copyright 2021, Example.com, Inc.,           |
+   |                   All Rights Reserved</Attribution>                        |
+   |      <SyndicationRight>open</SyndicationRight>                             |
+   |      <AdultContent>false</AdultContent>                                    |
+   |      <Language>en-us</Language>                                            |
+   |      <OutputEncoding>UTF-8</OutputEncoding>                                |
+   |      <InputEncoding>UTF-8</InputEncoding>                                  |
+   |   </OpenSearchDescription>                                                 |
+   |<---------------------------------------------------------------------------|
 =====
 
 [[sc-substitution-variable]]
@@ -107,12 +107,12 @@ The following table maps the <<core-query-parameters-table,core query parameters
 [cols="33,33,34",options="header",width=70%]
 |===
 |Core Query Parameter |OpenSearch Parameter |OpenSearch Geo Parameter
-|bbox |n/a |geo:box
-|datetime |n/a |time:start, time:end
-|limit |count |n/a
-|q |searchTerms |n/a
-|type |n/a |n/a
-|{recordId} |n/a |geo:uid
+|`bbox` |n/a |`geo:box`
+|`datetime` |n/a |`time:start`, `time:end`
+|`limit` |`count` |n/a
+|`q` |`searchTerms` |n/a
+|`type` |n/a |n/a
+|`{recordId}` |n/a |`geo:uid`
 |===
 
 [[sc-os-query-parameters]]
@@ -191,10 +191,10 @@ The following table maps the <<query-response,query response>> properties define
 [cols="50,50",options="header",width=70%]
 |===
 |OpenSearch response element  |Query response property
-|os:totalResults |<<req_core_rc-numberMatched,numberMatched>>
-|os:startIndex |<<rec_opensearch_param-startIndex,startIndex>>
-|os:itemsPerPage |<<req_core_param-limit,limit>>
-|os:Query |N/A
+|`os:totalResults` |<<req_core_rc-numberMatched,`numberMatched`>>
+|`os:startIndex` |<<rec_opensearch_param-startIndex,`startIndex`>>
+|`os:itemsPerPage` |<<req_core_param-limit,`limit`>>
+|`os:Query` |N/A
 |===
 
 include::recommendations/opensearch/REC_response-query.adoc[]
@@ -210,24 +210,24 @@ The following table maps the <<query-response,core query response properties>> t
 [cols="50,50",options="header",width=70%]
 |===
 |Core query response property |ATOM entry element
-|recordId           |atom:entry/atom:id
-|recordCreated      |dct:issued
-|recordUpdated      |dct:modified
-|links              |atom:link
-|type               |dc:type
-|title              |atom:entry/atom:title
-|description        |atom:entry/atom:summary
-|keywords           |atom:entry/atom:category
-|keywordsCodespace  |atom:entry/atom:category/@scheme
-|language           |dct:language
-|externalId         |n/a
-|created            |atom:entry/atom:published
-|updated            |atom:entry/atom:modified
-|publisher          |atom:entry/atom:creator
-|themes             |atom:entry/atom:category
-|formats            |atom/entry/atom:link[@rel="enclosure"]/@type
-|contactPoint       |dcat:contactPoint
-|license            |atom:link[@rel="license"]
-|rights             |atom:entry/atom:rights
-|extent             |atom:entry/georss:*
+|`recordId`           |`atom:entry/atom:id`
+|`recordCreated`      |`dct:issued`
+|`recordUpdated`      |`dct:modified`
+|`links`              |`atom:link`
+|`type`               |`dc:type`
+|`title`              |`atom:entry/atom:title`
+|`description`        |`atom:entry/atom:summary`
+|`keywords`           |`atom:entry/atom:category`
+|`keywordsCodespace`  |`atom:entry/atom:category/@scheme`
+|`language`           |`dct:language`
+|`externalId`         |n/a`
+|`created`            |`atom:entry/atom:published`
+|`updated`            |`atom:entry/atom:modified`
+|`publisher`          |`atom:entry/atom:creator`
+|`themes`             |`atom:entry/atom:category`
+|`formats`            |`atom/entry/atom:link[@rel="enclosure"]/@type`
+|`contactPoint`       |`dcat:contactPoint`
+|`license`            |`atom:link[@rel="license"]`
+|`rights`             |`atom:entry/atom:rights`
+|`extent`             |`atom:entry/georss:*`
 |===

--- a/core/standard/clause_12_encodings.adoc
+++ b/core/standard/clause_12_encodings.adoc
@@ -41,7 +41,7 @@ include::requirements/json/REQ_json-geojson-definition.adoc[]
 include::requirements/json/REQ_json-geojson-content.adoc[]
 
 [[schema_record]]
-.link:http://fix.me/record.yaml[Schema for a catalogue record in JSON(recordGeoJSON.yaml)]
+.link:http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/schemas/recordGeoJSON.yaml[Schema for a catalogue record in JSON(recordGeoJSON.yaml)]
 [source,YAML]
 ----
 include::../openapi/schemas/recordGeoJSON.yaml[]

--- a/core/standard/clause_12_encodings.adoc
+++ b/core/standard/clause_12_encodings.adoc
@@ -23,7 +23,7 @@ This section covers the requirements inherited from the API - Common standard. I
 * `{root}/api`: API Description
 * `{root}/conformance`: Conformance Classes
 * `{root}/collections`: Collections
-* `{root}/collections/{collectionid}`: Collection Information
+* `{root}/collections/{collectionId}`: Collection Information
 
 include::requirements/json/REQ_api-common.adoc[]
 
@@ -69,7 +69,7 @@ This section covers the requirements inherited from the API - Common standard. I
 * `{root}/api`: API Description
 * `{root}/conformance`: Conformance Classes
 * `{root}/collections`: Collections
-* `{root}/collections/{collectionid}`: Collection Information
+* `{root}/collections/{collectionId}`: Collection Information
 
 include::requirements/html/REQ_api-common.adoc[]
 
@@ -119,7 +119,7 @@ This section covers the requirements inherited from the API - Common standard. I
 * `{root}/api`: API Description
 * `{root}/conformance`: Conformance Classes
 * `{root}/collections`: Collections
-* `{root}/collections/{collectionid}`: Collection Information
+* `{root}/collections/{collectionId}`: Collection Information
 
 It is necessary to advertise conformance with this Requirements Class.
 

--- a/core/standard/clause_14_media_types.adoc
+++ b/core/standard/clause_14_media_types.adoc
@@ -13,23 +13,23 @@ None of these encodings are mandatory. An implementor of this standard may choos
 Support for HTML is recommended. HTML is the core language of the World Wide Web. An API that supports HTML will support browsing the spatial resources with a web browser and will also enable search engines to crawl and index those resources.
 
 === JSON Encoding
-Support for JSON is recommended. JSON is a commonly used format that is simple to understand and well supported by tools and software libraries.
+Support for JSON is recommended. JSON is a commonly used format that is simple to understand and well supported by numerous tools and software libraries.
 
-JSON structures documented in this standard are defined using JSON Schema. These schema are available in JSON and YAML formats from http://schemas.opengis.net/tbd[http://schemas.opengis.net/tbd]
+JSON structures documented in this standard are defined using JSON Schema. These schema are available in JSON and YAML formats from http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/schemas[http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/schemas]
 
 ==== GeoJSON
 "GeoJSON is a geospatial data interchange format based on JavaScript Object Notation (JSON). It defines several types of JSON objects and the manner in which they are combined to represent data about geographic features, their properties, and their spatial extents. GeoJSON uses a geographic coordinate reference system, World Geodetic System 1984, and units of decimal degrees." <<GeoJSON,IETF RFC 7946>>
 
-GeoJSON provides a simple way of representing OGC Records in JSON. It is best used for content which has a spatial extent that can be used with the World Geodetic System 1984 Coordinate Reference System.
+GeoJSON provides a simple way of representing OGC Records in JSON and is supported by numerous geospatial tools and software libraries. It is best used for content which has a spatial extent that can be used with the World Geodetic System 1984 Coordinate Reference System.
 
 === XML Encoding
 XML is a commonly used format that is well supported by tools and software libraries.
 
-XML structures documented in this standard are defined using XML Schema. These schema are available from http://schemas.opengis.net/ogcapi/records/part1/1.0/xml/core.xsd[OGC API Records Core XML Schema].
+XML structures documented in this standard are defined using XML Schema. These schema are available from http://schemas.opengis.net/ogcapi/records/part1/1.0/xml/core.xsd[OGC API - Records Core XML Schema].
 
 ==== ATOM
 
-Atom is an XML-based document format that describes lists of related resources known as "feeds".  Feeds are composed of a number of items, known as "entries", each describing a resource using an extensible set of attached metadata.  For example, each entry has an identifier and a title.
+Atom is an XML-based document format that describes lists of related resources known as "feeds". Feeds are composed of a number of items, known as "entries", each describing a resource using an extensible set of attached metadata.  For example, each entry has an identifier and a title.
 
 === Media Types
 A description of the MIME-types is mandatory for any OGC standard which involves data encodings. The list of suitable MIME-types for the API - Records standard in provided in <<api-records-mime-types>>.
@@ -39,10 +39,10 @@ A description of the MIME-types is mandatory for any OGC standard which involves
 [width="90%",cols="2,4"]
 |====
 ^|*Encoding* ^|*MIME Type*
-|HTML |text/html
-|JSON |application/json
-|GeoJSON |application/geo+json
-|ATOM |application/atom+xml
+|HTML |`text/html`
+|JSON |`application/json`
+|GeoJSON |`application/geo+json`
+|ATOM |`application/atom+xml`
 |====
 
 [[media-type-defaults]]

--- a/core/standard/clause_15_security.adoc
+++ b/core/standard/clause_15_security.adoc
@@ -3,6 +3,6 @@
 
 See:
 
-* https://github.com/opengeospatial/oapi_common/blob/master/core/clause_12_security_considerations.adoc
-* https://github.com/opengeospatial/ogcapi-features/blob/master/core/standard/clause_11_security_considerations.adoc
+* http://docs.ogc.org/DRAFTS/19-072.html#_security_considerations
+* http://docs.ogc.org/is/17-069r3/17-069r3.html#_security_considerations
 

--- a/core/standard/clause_2_conformance.adoc
+++ b/core/standard/clause_2_conformance.adoc
@@ -2,11 +2,11 @@
 
 Conformance with this standard shall be checked using the tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to claim conformance, are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.
 
-The one Standardization Target for this standard is Web APIs.
+The standardization targets of all conformance classes are "Web APIs".
 
-OGC API - Common provides a common foundation for OGC API standards. Therefore, this standard should be viewed as an extension to API - Common. Conformance to this standard requires demonstrated conformance to the applicable Conformance Classes of API - Common. 
+OGC API - Common provides a common foundation for OGC API standards. Therefore, this standard should be viewed as an extension to OGC API - Common. Conformance to this standard requires demonstrated conformance to the applicable Conformance Classes of OGC API - Common.
 
-This standard identifies six (6) Conformance Classes. The Conformance Classes implemented by an API are advertised through the `/conformance` path on the landing page. Each Conformance Class has an associated Requirements Class. The Requirements Classes define the functional requirements which will be tested through the associated Conformance Class.
+This standard identifies seven (7) Conformance Classes. The Conformance Classes implemented by an API are advertised through the `/conformance` path. Each Conformance Class has an associated Requirements Class. The Requirements Classes define the functional requirements which will be tested through the associated Conformance Class.
 
 The Requirements Classes for OGC API - Records are:
 
@@ -18,7 +18,7 @@ The Requirements Classes for OGC API - Records are:
 * <<requirements-class-atom-clause,ATOM-Record>>
 * <<requirements-class-html-clause,HTML-Record>>
 
-The _Core_ Requirements Class is the minimal useful service interface for the OGC Records API. The requirements specified in this Requirements Class are mandatory for all implementations of API - Records.  The core defines a set of mandatory properties (core queryables) that every record must contain, a set of core query parameters that support bounding box spatial queries, temporal queries, full text searching, parameters for sorting responses.
+The _Core_ Requirements Class is the minimal useful service interface for OGC API - Records. The requirements specified in this class are mandatory for all implementations of this standard. The core defines a baseline record schema, resource paths, a set of mandatory properties (core queryables) that every record must contain, a set of core query parameters that support bounding box spatial queries, temporal queries, full-text searching, parameters for sorting responses, and error handling.
 
 The _Sorting_ Requirements Class defines the requirements to support sorting of records in a query response.
 

--- a/core/standard/clause_2_conformance.adoc
+++ b/core/standard/clause_2_conformance.adoc
@@ -18,11 +18,11 @@ The Requirements Classes for OGC API - Records are:
 * <<requirements-class-atom-clause,ATOM-Record>>
 * <<requirements-class-html-clause,HTML-Record>>
 
-The _Core_ Requirements Class is the minimal useful service interface for OGC API - Records. The requirements specified in this class are mandatory for all implementations of this standard. The core defines a baseline record schema, resource paths, a set of mandatory properties (core queryables) that every record must contain, a set of core query parameters that support bounding box spatial queries, temporal queries, full-text searching, parameters for sorting responses, and error handling.
+The _Core_ Requirements Class is the minimal useful service interface for OGC API - Records. The requirements specified in this class are mandatory for all implementations of this standard. The core defines a baseline record schema, resource paths, a set of mandatory properties (core queryables) that every record must contain, a set of core query parameters that support bounding box spatial queries, temporal queries, property queries, full-text searching, and error handling.
 
 The _Sorting_ Requirements Class defines the requirements to support sorting of records in a query response.
 
-The _Filter using the Common Query Language_ Requirements Class defines the requirements to support record filtering using CQL.
+The _Filter using the Common Query Language (CQL)_ Requirements Class defines the requirements to support record filtering using CQL.
 
 The _OpenSearch_ Requirements Class defines the requirements to support query by OpenSearch clients.
 
@@ -47,7 +47,7 @@ OGC Compliance Testing web site.
 |<<ats_sorting,Sorting>> |http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/sorting
 |<<ats_cql,CQL>> |http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/cql
 |<<ats_opensearch,OpenSearch>> |http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/opensearch
-|<<ats_json,JSON-Record>> |http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/JSON
+|<<ats_json,JSON-Record>> |http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json
 |<<ats_atom,ATOM-Record>> |http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/atom
 |<<ats_atom,HTML-Record>> |http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html
 |===

--- a/core/standard/clause_3_references.adoc
+++ b/core/standard/clause_3_references.adoc
@@ -32,4 +32,4 @@ The following normative documents contain provisions that, through reference in 
 * W3C: W3C JSON-LD 1.0, A JSON-based Serialization for Linked Data. http://www.w3.org/TR/json-ld/, 2014
 * W3C: W3C JSON-LD 1.0 Processing Algorithms and API. http://www.w3.org/TR/json-ld-api, 2014
 * W3C: W3C RDF 1.1 Concepts and Abstract Syntax. https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/, 2014
-* [[OAFeat-3]] OGC 19-19-079: *OGC API - Features - Part 3: Filter and the Common Query Language (CQL)*, https://docs.ogc.org/DRAFTS/19-079.html
+* [[OAFeat-3]] OGC 19-19-079: *OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)*, https://docs.ogc.org/DRAFTS/19-079.html

--- a/core/standard/clause_3_references.adoc
+++ b/core/standard/clause_3_references.adoc
@@ -32,4 +32,4 @@ The following normative documents contain provisions that, through reference in 
 * W3C: W3C JSON-LD 1.0, A JSON-based Serialization for Linked Data. http://www.w3.org/TR/json-ld/, 2014
 * W3C: W3C JSON-LD 1.0 Processing Algorithms and API. http://www.w3.org/TR/json-ld-api, 2014
 * W3C: W3C RDF 1.1 Concepts and Abstract Syntax. https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/, 2014
-* [[OAFeat-3]] OGC 19-19-079: *OGC API - Features - Part 3: Filter and the Common Query Language (CQL)*, http://docs.opengeospatial.org/DRAFTS/19-079.html
+* [[OAFeat-3]] OGC 19-19-079: *OGC API - Features - Part 3: Filter and the Common Query Language (CQL)*, https://docs.ogc.org/DRAFTS/19-079.html

--- a/core/standard/clause_3_references.adoc
+++ b/core/standard/clause_3_references.adoc
@@ -1,20 +1,20 @@
 == References
 The following normative documents contain provisions that, through reference in this text, constitute provisions of this document. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. For undated references, the latest edition of the normative document referred to applies.
 
-* [[rfc2616]] Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., Berners-Lee, T.: IETF RFC 2616, *HTTP/1.1*, http://tools.ietf.org/rfc/rfc2616.txt[RFC 2616]
-* [[rfc2818]]  Rescorla, E.: IETF RFC 2818, *HTTP Over TLS*, http://tools.ietf.org/rfc/rfc2818.txt[RFC 2818]
-* [[rfc3339]] Klyne, G., Newman, C.: IETF RFC 3339, *Date and Time on the Internet: Timestamps*, http://tools.ietf.org/rfc/rfc3339.txt[RFC 3339]
+* [[rfc2616]] Fielding, R., Gettys, J., Mogul, J., Frystyk, H., Masinter, L., Leach, P., Berners-Lee, T.: IETF RFC 2616, *HTTP/1.1*, https://tools.ietf.org/rfc/rfc2616.txt[RFC 2616]
+* [[rfc2818]]  Rescorla, E.: IETF RFC 2818, *HTTP Over TLS*, https://tools.ietf.org/rfc/rfc2818.txt[RFC 2818]
+* [[rfc3339]] Klyne, G., Newman, C.: IETF RFC 3339, *Date and Time on the Internet: Timestamps*, https://tools.ietf.org/rfc/rfc3339.txt[RFC 3339]
 * [[rfc3986]] Berners-Lee, T., Fielding, R., Masinter, L.: IETF RFC 3986, *Uniform Resource Identifier (URI): Generic Syntax*, https://tools.ietf.org/html/rfc3986[RFC 3986]
 * [[rfc3987]] Duerst, M., Suignard, M.: IETF RFC 3987, *Internationalized Resource Identifiers (IRIs)*, https://tools.ietf.org/html/rfc3987[RFC 3987]
 * [[rfc4287]] Nottingham, M., Sayre, R.: IETF RFC 4287, *The Atom Syndication Format*, https://tools.ietf.org/html/rfc4287[RFC 4287]
 * [[rfc6570]] Gregorio, J., Fielding, R., Hadley, M., Nottingham, M., Orchard, D.: IETF RFC 6570, *URI Template*, https://tools.ietf.org/html/rfc6570[RFC 6570]
 * [[GeoJSON]] IETF RFC 7946: *The GeoJSON Format*, https://tools.ietf.org/rfc/rfc7946.txt[GeoJSON]
-* [[rfc8288]] Nottingham, M.: IETF RFC 8288, *Web Linking*, http://tools.ietf.org/rfc/rfc8288.txt[RFC 8288]
+* [[rfc8288]] Nottingham, M.: IETF RFC 8288, *Web Linking*, https://tools.ietf.org/rfc/rfc8288.txt[RFC 8288]
 
 * [[OAPI_Common]] OGC 19-072: *OGC API (OAPI) Common Specification*, (Draft) https://github.com/opengeospatial/oapi_common[API Common]
 * [[OpenAPI]] Open API Initiative: *OpenAPI Specification 3.0.2*, https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md[OpenAPI]
-* [[schema.org]] *Schema.org*: http://schema.org/docs/schemas.html[Schema.org]
-* [[HTML5]] W3C: *HTML5*, W3C Recommendation, http://www.w3.org/TR/html5/[HTML5]
+* [[schema.org]] *Schema.org*: https://schema.org/docs/schemas.html[Schema.org]
+* [[HTML5]] W3C: *HTML5*, W3C Recommendation, https://www.w3.org/TR/html5/[HTML5]
 * [[RDF]] W3C, *RDF 1.1 Semantics*, February 2014, https://www.w3.org/TR/rdf11-mt/
 * [[xml]] W3C, *Extensible Markup Language (XML) 1.0 (Fifth Edition)*, November 2008, https://www.w3.org/TR/xml/
 * [[opensearch]] OASIS, https://docs.oasis-open.org/search-ws/searchRetrieve/v1.0/os/part4-opensearch/searchRetrieve-v1.0-os-part4-opensearch.html#_Toc313525766[searchRerieve: Part 4. APD Binding for OpenSearch Version 1.0]
@@ -29,7 +29,7 @@ The following normative documents contain provisions that, through reference in 
 * IETF: RFC 2392, 1998
 [18] IETF: RFC 3986, 2005
 [19] IETF: RFC 7159, The JavaScript Object Notation (JSON) Data Interchange Format  https://www.ietf.org/rfc/rfc7159.txt, 2014
-* W3C: W3C JSON-LD 1.0, A JSON-based Serialization for Linked Data. http://www.w3.org/TR/json-ld/, 2014
-* W3C: W3C JSON-LD 1.0 Processing Algorithms and API. http://www.w3.org/TR/json-ld-api, 2014
+* W3C: W3C JSON-LD 1.0, A JSON-based Serialization for Linked Data. https://www.w3.org/TR/json-ld/, 2014
+* W3C: W3C JSON-LD 1.0 Processing Algorithms and API. https://www.w3.org/TR/json-ld-api, 2014
 * W3C: W3C RDF 1.1 Concepts and Abstract Syntax. https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/, 2014
 * [[OAFeat-3]] OGC 19-19-079: *OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)*, https://docs.ogc.org/DRAFTS/19-079.html

--- a/core/standard/clause_4_terms_and_definitions.adoc
+++ b/core/standard/clause_4_terms_and_definitions.adoc
@@ -1,5 +1,5 @@
 == Terms and Definitions
-This document uses the terms defined in Sub-clause 5 of https://github.com/opengeospatial/oapi_common/blob/master/19-072.pdf[OGC API - Common Part 1] (OGC 19-072), which is based on the ISO/IEC Directives, Part 2, Rules for the structure and drafting of International Standards. In particular, the word “shall” (not “must”) is the verb form used to indicate a requirement to be strictly followed to conform to this standard.
+This document uses the terms defined in Sub-clause 5 of https://docs.ogc.org/DRAFTS/19-072.html[OGC API - Common Part 1] (OGC 19-072), which is based on the ISO/IEC Directives, Part 2, Rules for the structure and drafting of International Standards. In particular, the word "shall" (not "must") is the verb form used to indicate a requirement to be strictly followed to conform to this standard.
 
 For the purposes of this document, the following additional terms and definitions apply.
 
@@ -22,7 +22,7 @@ represents an accessible form of a *dataset* (DCAT)
 EXAMPLE: a downloadable file, an RSS feed or a web service that provides the data.
 
 === Executable Test Suite (ETS)
-set of code (e.g. Java and CTL) that provides runtime tests for the assertions defined by the ATS. Test data required to do the tests are part of the ETS https://portal.opengeospatial.org/files/?artifact_id=55234[(OGC 08-134)]
+set of code (e.g. Java and CTL) that provides runtime tests for the assertions defined by the ATS. Test data required to do the tests are part of the ETS https://portal.ogc.org/files/?artifact_id=55234[(OGC 08-134)]
 
 === Record
 atomic unit of information of a catalogue that is used to provide information about a particular resource

--- a/core/standard/clause_5_conventions.adoc
+++ b/core/standard/clause_5_conventions.adoc
@@ -38,7 +38,7 @@ UML diagrams and XML code fragments adhere to the namespace conventions shown in
 |*GML/XML prefix* ^|*Namespace URL* ^|*Description*
 
 |atom |http://www.w3.org/2005/Atom |ATOM namespace
-|core |http://www.opengis.net/ogcapi-record-1/1.0 |OGC API Records core elements
+|core |http://www.opengis.net/ogcapi-record-1/1.0 |OGC API - Records core elements
 |dc |http://purl.org/dc/elements/1.1/ |Dublin core elements
 |dcat |http://www.w3.org/ns/dcat# |DCAT vocabulary
 |dct |http://purl.org/dc/terms/ |Dublin core terms

--- a/core/standard/clause_5_conventions.adoc
+++ b/core/standard/clause_5_conventions.adoc
@@ -1,20 +1,20 @@
 == Conventions
+
 The following conventions will be used in this document. Examples of conventions are symbols, abbreviations, use of XML schema, or special notes regarding how to read the document.
 
 === Identifiers
-The normative provisions in this standard are denoted by the URI
 
-http://www.opengis.net/spec/ogcapi-records-1/1.0
+The normative provisions in this standard are denoted by the URI `http://www.opengis.net/spec/ogcapi-records-1/1.0`.
 
 All requirements and conformance tests that appear in this document are denoted by partial URIs which are relative to this base.
 
 === Examples
 
-Most of the examples provided in this standard are encoded in JSON. JSON was chosen because it is widely understood by implementers and easy to include in a text document. This convention should NOT be interpreted as a requirement that JSON must be used. Implementors are free to use any format they desire as long as there is a Conformance Class for that format and the API advertises its support for that Conformance Class.
+Most of the examples provided in this standard are encoded in JSON. JSON is chosen because it is widely understood by implementers and easy to include in a text document. This convention should NOT be interpreted as a requirement that JSON must be used. Implementors are free to use any format they desire as long as there is a Conformance Class for that format and the API advertises its support for the associated Conformance Class.
 
 === Schema
 
-JSON Schema is used throughout this standard to define the structure of resources. These schema are typically represented using YAML encoding. This convention is for the ease of the user. It does not prohibit the use of another schema language or encoding. Nor does it indicate that JSON schema is required. Implementations should use a schema language and encoding appropriate for the format of the resource.
+JSON Schema is used throughout this standard to define the structure of resources. These schema are typically represented using YAML encoding. This convention is for the ease of the user. It does not prohibit the use of another schema language or encoding. Nor does it indicate that JSON Schema is required. Implementations should use a schema language and encoding appropriate for the format of the resource.
 
 === UML Notation
 

--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -47,12 +47,18 @@ Where:
 [[record-schema-overview]]
 === Record Schema
 
-T.B.D.
+The core information unit in a catalogue is a record.  A record may describe
+any resource (dataset, service, style, etc.). and as such provides a generic
+baseline to ensure broad interoperability.  Note that the record model is also
+extensible, and that it is envisioned that information communities will create
+profiles or extensions. This will ensure broad interoperability to lower the
+barrier to processing and interpretation of record metadata, as well as allow
+for domain-specific representations.
 
 [[api-behavior-model-overview]]
 === API Behavior Model
 
-This standard is designed to be compatible but not conformant with the OGC Catalogue Service for the Web (CSW). This allows OGC API - Records implementations and CSW implementations to co-exist in a single environment.
+This standard is designed to be compatible (but not conformant) with the OGC Catalogue Service for the Web (CSW). This allows OGC API - Records implementations and CSW implementations to co-exist in a single environment.
 
 The https://www.ogc.org/standards/cat[OGC Catalogue Service standard version 3] provides an abstract core model of metadata (data about data) describing a number of different information types (data, services, styles, processes, etc.) on which the classic operations GetCapabilities, DescribeRecord, GetRecords, and GetRecordById can be explained naturally. This model consists of a 1..n catalogue collections residing in a CSW backend repository. It holds service metadata describing service qualities (identification, contact, operations, filtering capabilities, etc.). At its heart, a catalogue may provide discovery services to any number of metadata repositories. The core catalogue model is based on an extension of Dublin Core (CSW Record). Application profiles can be developed to target specific metadata information models (such as ISO 19115/19139, etc.).
 

--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -4,9 +4,9 @@
 [[general-overview]]
 === General
 
-The OGC API family of standards enable access to resources using the HTTP protocol and its' associated operations (GET, PUT, POST, etc.). OGC API - Common defines a set of features which are applicable to all OGC APIs. Other OGC standards extend API - Common with features specific to a resource type. 
+The OGC API family of standards enable access to resources using the HTTP protocol and its native operations (GET, PUT, POST, etc.). OGC API - Common defines a set of features which are applicable to all OGC APIs. Other OGC standards extend API - Common with features specific to a resource type. 
 
-This standard, OGC API - Records - Part 1: Core, extends OGC API Common to:
+This standard extends OGC API Common to:
 
 . Provide modern API patterns and encodings to facilitate further lowering the barrier to finding the existence of spatial resources on the Web.
 . Provide functionality comparable to that of the <<api-behavior-model-overview,OGC Catalogue Service (CSW) standard>> so that a facade can be created over legacy services thus allowing them to participate in the new OGC API ecosystem.
@@ -29,11 +29,9 @@ The following table, <<records-paths,Record API Paths>>, summarizes the access p
 ^|**Path Template** ^|**Relation** ^|**Resource** 
 3+^|**Common**
 |<<landing-page,{root}/>> |none |Landing page
-|<<api-definition,{root}/api>> |`service-desc` +
-or +
-`service-doc` |API Description (optional)
-|<<conformance-classes,{root}/conformance>> |`conformance` |Conformance Classes
-|<<collections,{root}/collections>> |`data` |Metadata describing the spatial collections available from this API.
+|<<api-definition,{root}/api>> |`service-desc` or `service-doc` |API Description (optional)
+|<<conformance-classes,{root}/conformance>> | `conformance` |Conformance Classes
+|<<collections,{root}/collections>> | `data` |Metadata describing the spatial collections available from this API.
 |<<collectionInfo,{root}/collections/{collectionId}>> | |Metadata describing the collection which has the unique identifier `{collectionId}`
 3+^|**Records**
 |<<records-access,{root}/collections/{collectionId}/items>> |`items` |Search results based on querying the service for records satisfying 0..n query parameters.
@@ -42,9 +40,9 @@ or +
 
 Where:
 
-* {root} = Base URI for the API server
-* {collectionId} = an identifier for a specific collection
-* {recordId} = an identifier for a specific record within a collection
+* `{root}` = Base URI for the API server
+* `{collectionId}` = an identifier for a specific collection
+* `{recordId}` = an identifier for a specific record within a collection
 
 [[record-schema-overview]]
 === Record Schema
@@ -54,9 +52,9 @@ T.B.D.
 [[api-behavior-model-overview]]
 === API Behavior Model
 
-The Records API is designed to be compatible but not conformant with the OGC Catalogue Service for the Web (CSW). This allows OGC API - Records implementations and CSW implementations to co-exist in a single processing environment.
+This standard is designed to be compatible but not conformant with the OGC Catalogue Service for the Web (CSW). This allows OGC API - Records implementations and CSW implementations to co-exist in a single environment.
 
-The https://www.opengeospatial.org/standards/cat[OGC Catalogue Service standard version 3] provides an abstract core model of metadata (data about data) describing a number of different information types (data, services, styles, processes, etc.) on which the classic operations GetCapabilities, DescribeRecord, GetRecords, and GetRecordById can be explained naturally. This model consists of a 1..n catalogue collections residing in a CSW backend repository. It holds service metadata describing service qualities (identification, contact, operations, filtering capabilities, etc.). At its heart, a catalogue may provide discovery services to any number of metadata repositories. The core catalogue model is based on an extension of Dublin Core (CSW Record). Application profiles can be developed to target specific metadata information models (such as ISO 19115/19139, etc.).
+The https://www.ogc.org/standards/cat[OGC Catalogue Service standard version 3] provides an abstract core model of metadata (data about data) describing a number of different information types (data, services, styles, processes, etc.) on which the classic operations GetCapabilities, DescribeRecord, GetRecords, and GetRecordById can be explained naturally. This model consists of a 1..n catalogue collections residing in a CSW backend repository. It holds service metadata describing service qualities (identification, contact, operations, filtering capabilities, etc.). At its heart, a catalogue may provide discovery services to any number of metadata repositories. The core catalogue model is based on an extension of Dublin Core (CSW Record). Application profiles can be developed to target specific metadata information models (such as ISO 19115/19139, etc.).
 
 Discussion has shown that the API model also assumes underlying service and object descriptions, so a convergence seems possible. In any case, it will be advantageous to have a similar "mental model" of the server store organization on hand to explain the various functionalities introduced below.
 
@@ -70,9 +68,9 @@ The Records API offers various levels of search capability of escalating complex
 * free text
 * equality predicates based on a subset of core queryables (e.g. by resource type, by external identifier)
 
-This specification also includes a conformance class that allows a catalogue to be searched using  https://portal.opengeospatial.org/files/?artifact_id=56866[OpenSearch Geo].  OpenSearch Geo gives the user more control over the kinds of geometries, beyond a bounding box, that can be used to define an area of interest.
+This specification also includes a conformance class that allows a catalogue to be searched using  https://portal.ogc.org/files/?artifact_id=56866[OpenSearch Geo].  OpenSearch Geo gives the user more control over the kinds of geometries, beyond a bounding box, that can be used to define an area of interest.
 
-Finally extensions, such as the https://docs.ogc.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filter and the Common Query Language (CQL)], may be used with the Records API to support complex search capabilities using a rich set of logically connected search predicates where the user has full control over to query expression.
+Finally extensions, such as the https://docs.ogc.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)], may be used with the Records API to support complex search capabilities using a rich set of logically connected search predicates where the user has full control over to query expression.
 
 [[dependencies-overview]]
 === Dependencies

--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -60,7 +60,7 @@ Discussion has shown that the API model also assumes underlying service and obje
 
 === Search
 
-The Records API offers various levels of search capability of escalating complexity and capability.  At the core is the ability to search the catalogue by specifying:
+This standard offers various levels of search capability. At the core is the ability to search the catalogue with the following constructs:
 
 * a bounding box
 * a time instant or time period
@@ -68,14 +68,14 @@ The Records API offers various levels of search capability of escalating complex
 * free text
 * equality predicates based on a subset of core queryables (e.g. by resource type, by external identifier)
 
-This specification also includes a conformance class that allows a catalogue to be searched using  https://portal.ogc.org/files/?artifact_id=56866[OpenSearch Geo].  OpenSearch Geo gives the user more control over the kinds of geometries, beyond a bounding box, that can be used to define an area of interest.
+This standard also includes a conformance class that allows a catalogue to be searched using https://portal.ogc.org/files/?artifact_id=56866[OpenSearch Geo].  OpenSearch Geo gives the user more control over the geometry types, that can be used to define an area of interest (i.e. beyond a bounding box).
 
-Finally extensions, such as the https://docs.ogc.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)], may be used with the Records API to support complex search capabilities using a rich set of logically connected search predicates where the user has full control over to query expression.
+Finally, extensions such as the https://docs.ogc.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filtering and the Common Query Language (CQL)], may be used with this standard to support complex search capabilities using a rich set of logically connected search predicates where the user has finer control over a query.
 
 [[dependencies-overview]]
 === Dependencies
 
-The OGC API - Records standard is an extension of the OGC API - Common standard. Therefore, an implementation of OGC API - Records must first satisfy the appropriate Requirements Classes from API - Common. The following table, <<mapping-to-common,Mapping API - Records Sections to API - Common Requirements Classes>>, identifies the OGC API - Common Requirements Classes which are applicable to each section of this Standard. Instructions on when and how to apply these Requirements Classes are provided in each section.
+This standard is an extension of the OGC API - Common standard. Therefore, an implementation of OGC API - Records must first satisfy the appropriate Requirements Classes from OGC API - Common. The following table, <<mapping-to-common,Mapping API - Records Sections to API - Common Requirements Classes>>, identifies the OGC API - Common Requirements Classes which are applicable to each section of this standard. Instructions on when and how to apply these Requirements Classes are provided in each section.
 
 [[mapping-to-common]]
 [reftext='{table-caption} {counter:table-num}']

--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -72,7 +72,7 @@ The Records API offers various levels of search capability of escalating complex
 
 This specification also includes a conformance class that allows a catalogue to be searched using  https://portal.opengeospatial.org/files/?artifact_id=56866[OpenSearch Geo].  OpenSearch Geo gives the user more control over the kinds of geometries, beyond a bounding box, that can be used to define an area of interest.
 
-Finally extensions, such as the http://docs.opengeospatial.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filter and the Common Query Language (CQL)], may be used with the Records API to support complex search capabilities using a rich set of logically connected search predicates where the user has full control over to query expression.
+Finally extensions, such as the https://docs.ogc.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filter and the Common Query Language (CQL)], may be used with the Records API to support complex search capabilities using a rich set of logically connected search predicates where the user has full control over to query expression.
 
 [[dependencies-overview]]
 === Dependencies

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -279,7 +279,7 @@ The requirements for handling unsuccessful requests are provided in <<http-respo
 
 The primary unit of information in a catalogue is a record. Tables <<core-queryables-record-table>> and <<core-queryables-resource-table>> in this clause present a generic set of properties, called _**core queryables**_, that may be included in a catalogue record.  The choice of which properties to include in the set of core queryables was primarily informed by the following record models:
 
-* The http://docs.opengeospatial.org/is/12-168r6/12-168r6.html#17[core catalogue schema] from the https://www.ogc.org/standards/cat[OGC® Catalogue Services 3.0] suite of standards,
+* The https://docs.ogc.org/is/12-168r6/12-168r6.html#17[core catalogue schema] from the https://www.ogc.org/standards/cat[OGC® Catalogue Services 3.0] suite of standards,
 * the https://www.w3.org/TR/vocab-dcat/[Data Catalog Vocabular (DCAT) - Version 2] specification.
 * and the https://www.unece.org/fileadmin/DAM/stats/documents/ece/ces/ge.58/2017/mtg3/2017-UNECE-topic-i-EC-GeoDCAT-ap-paper.pdf[GeoDCAT-AP] specification.
 
@@ -326,7 +326,7 @@ supported at the `/collections/{collectionId}/items` endpoint.
 |externalid |An equality predicate consistent of a comma-separated list of external resource identifiers. Only records with the specified external identifiers shall appear in the response set.
 |===
 
-The query parameters http://docs.opengeospatial.org/DRAFTS/20-024.html#bbox-parameter-requirements[`bbox`], http://docs.opengeospatial.org/DRAFTS/20-024.html#datetime-parameter-requirements[`datetime`] and http://docs.opengeospatial.org/DRAFTS/20-024.html#limit-parameter-requirements[`limit`] are inherited from API -Common.  All requirements and recommendations in API - Common regarding these parameters also apply for API - Records.
+The query parameters https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`bbox`], https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`datetime`] and https://docs.ogc.org/DRAFTS/20-024.html#limit-parameter-requirements[`limit`] are inherited from API -Common.  All requirements and recommendations in API - Common regarding these parameters also apply for API - Records.
 
 The query parameters `q`, `type` and `externalid` are specific to API - Records.
 

--- a/core/standard/clause_7_core.adoc
+++ b/core/standard/clause_7_core.adoc
@@ -17,19 +17,19 @@ The `Core` Requirements Class defines the requirements for locating, understandi
 [[core-dependencies-section]]
 === Dependencies
 
-The OGC API - Records standard is an extension of the OGC API - Common standard. Therefore, an implementation of API - Records must first satisfy the appropriate Requirements Classes from API - Common.
+This standard standard is an extension of the OGC API - Common standard. Therefore, an implementation of OGC API - Records must first satisfy the appropriate Requirements Classes from OGC API - Common.
 
 include::requirements/core/REQ_api-common.adoc[]
 
 [[api-platform-section]]
 === Platform
 
-API - Common defines a set of common capabilities which are applicable to any OGC Web API. Those capabilities provide the platform upon which resource-specific APIs can be built. This section describes those capabilities and any modifications needed to better support Record resources.
+OGC API - Common defines a set of shared capabilities which are applicable to any OGC Web API. Those capabilities provide the platform upon which resource-specific APIs can be built. This section describes those capabilities and any modifications needed to properly support Record resources.
 
 [[landing-page]]
 ==== API landing page
 
-The landing page provides links to start exploration of the resources offered by an API. Its most important component is a list of links. OGC API - Common already requires some common links. Those links are sufficient for this standard.
+The landing page provides a list of qualified links to begin exploration of the resources offered by an API. Links required by OGC API - Common are sufficient for this standard.
 
 .Dependencies
 [width="90%"]
@@ -39,15 +39,15 @@ The landing page provides links to start exploration of the resources offered by
 
 ===== Operation
 
-The `Landing Page` operation is defined in the `Core` conformance class of API - Common. No modifications are needed to support `Record` resources. The `Core` conformance class specifies only one way of performing this operation:
+The `Landing Page` operation is defined in the `Core` conformance class of OGC API - Common. No modifications are needed to support `Record` resources. The `Core` conformance class specifies only one way of performing this operation:
 
 . Issue a `GET` request on the `{root}/` path
 
-Support for `GET` on the `{root}/` path is required by API - Common.
+Support for `GET` on the `{root}/` path is required by OGC API - Common.
 
 ===== Response
 
-A successful response to the `Landing Page` operation is defined in API - Common. The schema for this resource is provided in <<landingPage-schema>>.
+A successful response to the `Landing Page` operation is defined in OGC API - Common. The schema for this resource is provided in <<landingPage-schema>>.
 
 [#landingPage-schema,reftext='Landing Page Response Schema']
 .Landing Page Response Schema
@@ -72,7 +72,7 @@ The requirements for handling unsuccessful requests are provided in <<http-respo
 [[api-definition]]
 ==== API definition
 
-Every API is required to provide a definition document that describes the capabilities of that API. This definition document can be used by developers to understand the API, by software clients to connect to the server, or by development tools to support the implementation of servers and clients.
+Every API is required to provide a definition document that describes the capabilities of that API. This definition document can be used by developers to better understand the API, by software clients to connect to the server, or by development tools to support the implementation of servers and clients.
 
 .Dependencies
 [width="90%"]
@@ -82,16 +82,16 @@ Every API is required to provide a definition document that describes the capabi
 
 ===== Operation
 
-This operation is defined in the `Core` conformance class of API - Common. No modifications are needed to support `Records` resources. The `Core` conformance class describes two ways of performing this operation:
+This operation is defined in the `Core` conformance class of OGC API - Common. No modifications are needed to support `Records` resources. The `Core` conformance class describes two ways of performing this operation:
 
 . Issue a `GET` request on the `{root}/api` path
-. Follow the `service-desc` or `service-doc` link on the landing page
+. Follow the `service-desc` or `service-doc` links on the landing page
 
-Only the link is required by API - Common.
+Only the link is required by OGC API - Common.
 
 ===== Response
 
-A successful response to the API Definition request is a resource which documents the design of the API. API - Common leaves the selection of format for the API Definition response to the API implementor. However, the options are limited to those which have been defined in the API - Common standard. At this time OpenAPI 3.0 is the only option provided.
+A successful response to the API Definition request is a resource which documents the design of the API. OGC API - Common leaves the selection of format for the API Definition response to the implementation. However, the options are limited to those which have been defined in the OGC API - Common standard. At this time, OpenAPI 3.0 is the only option provided.
 
 ===== Error situations
 
@@ -100,7 +100,7 @@ The requirements for handling unsuccessful requests are provided in <<http-respo
 [[conformance-classes]]
 ==== Declaration of conformance classes
 
-To support "generic" clients that want to access multiple OGC API standards and extensions - and not "just" a specific API / server, the API has to declare the conformance classes it claims to have implemented.
+To support "generic" clients that want to access multiple OGC API standards and extensions - and not "just" a specific API / server, the API must declare the conformance classes it claims to have implemented.
 
 .Dependencies
 [width="90%"]
@@ -121,7 +121,7 @@ Both techniques are required by API - Common.
 
 ===== Response
 
-A successful response to the Conformance operation is a list of URLs. Each URL identifies an OGC Conformance Class for which this API claims conformance. The schema for this resource is defined in API - Common and provided for reference in <<conformance-schema>>.
+A successful response to the Conformance operation is a list of URLs. Each URL identifies an OGC Conformance Class for which this API claims conformance. The schema for this resource is defined in OGC API - Common and provided for reference in <<conformance-schema>>.
 
 include::requirements/core/REQ_conformance.adoc[]
 
@@ -134,7 +134,7 @@ include::recommendations/core/PER_additional-conformance.adoc[]
 include::../openapi/schemas/common/confClasses.yaml[]
 ----
 
-The following JSON fragment is an example of a response to an OGC API - Records conformance operation.
+The following JSON payload is an example of a response to an OGC API - Records conformance operation.
 
 [#conformance-example,reftext=`Conformance Information Example`]
 .Conformance Information Example
@@ -150,14 +150,14 @@ The requirements for handling unsuccessful requests are provided in <<http-respo
 [[collection-access]]
 === Collection access
 
-API - Common starts with the assumption that spatial resources are organized
-into collections. An API will expose one or more collections. The API - Common
+OGC API - Common assumes that spatial resources are organized into collections.
+An API will expose one or more those collections. The OGC API - Common
 Collections Conformance Class defines how to organize and provide access to a
 collection of collections.
 
-This standard extends the API - Common `Collections` conformance class to
-support collections of records, then extends that class to support `Record`
-unique capabilities.
+This standard extends the OGC API - Common `Collections` conformance class to
+support collections of records, then extends that class to support capabilities
+specific to the `Record` concept.
 
 [[collections-metadata]]
 ==== Collections Metadata
@@ -174,7 +174,7 @@ collections available from this API.
 [[collections-meta-operation]]
 ===== Operation
 
-This operation is defined in the `Collections` conformance class of API - Common.
+This operation is defined in the `Collections` conformance class of OGC API - Common.
 No modifications are required to support `Record` resources. The `Collections`
 conformance class describes two ways of performing this operation:
 
@@ -190,7 +190,7 @@ required by API - Common.
 A successful response to the <<collections-meta-operation,Collections Operation>>
  is a document that contains summary metadata for each collection accessible though the API.
 
-In a typical API deployment the <<collection-meta-operation,collections response>>
+In a typical API deployment, the <<collection-meta-operation,collections response>>
 will list collections of all offered resource types.  The collections where
 the value of the `itemType` property (JSONPath: `$.collections[*].itemType`)
 is `record` are collections of records (i.e. catalogues).
@@ -202,7 +202,7 @@ is `record` are collections of records (i.e. catalogues).
 include::../openapi/schemas/common/collections.yaml[]
 ----
 
-The following JSON document is an example of a response to an OGC API - Records
+The following JSON payload is an example of a response to an OGC API - Records
 <<collections-meta-operation,Collections>> operation.
 
 [#conllections-example,reftext=`Collections Example`]
@@ -235,21 +235,21 @@ Collection in the <<collections-metadata,`/collections`>> response.
 This operation is defined in the `Collections` conformance class of API - Common.
 No modifications are required to support `Records` resources.
 
-. Issue a `GET` request on the `{root}/collections/{collectionid}` path
+. Issue a `GET` request on the `{root}/collections/{collectionId}` path
 
 [[collection-identifier]]
-The {collectionid} parameter is the unique identifier for a single collection 
-offered by the API. The list of valid values for `{collectionid}` is provided
+The {collectionId} parameter is the unique identifier for a single collection 
+offered by the API. The list of valid values for `{collectionId}` is provided
 in the <<collections-metadata,`/collections`>> response.
 
-Support for the `/collections/{collectionid}` path is required by API - Common.
+Support for the `/collections/{collectionId}` path is required by OGC API - Common.
 
 [[collection-info-response]]
 ===== Response
 
 A successful response to the <<collection-info-operation,Collection>> operation
 is a set of metadata that describes the collection identified by the
-<<collection-identifier,`{collectionid}`>> parameter.
+<<collection-identifier,`{collectionId}`>> parameter.
 
 [#collectionInfo-schema,reftext='Collection Information Response Schema']
 .Collection Information Response Schema
@@ -258,7 +258,7 @@ is a set of metadata that describes the collection identified by the
 include::../openapi/schemas/common/collectionInfo.yaml[]
 ----
 
-The following JSON fragment is an example of a response to an OGC API - Records
+The following JSON payload is an example of a response to an OGC API - Records
 Collection Information operation.
 
 [#collection-info-example,reftext=`Collection Information Example`]
@@ -293,9 +293,10 @@ Although this document does not mandate any particular encoding for a record, th
 * an <<record_atom_encoding,ATOM>> record encoding,
 * and an <<record_html_encoding,HTML>> encoding.
 
-Other encoding are allow but are not described in this document.
+Other encodings are allowed but are not described in this document (i.e. they can be implemented as
+part of separate Requirements Classes).
 
-This clause describes how to search a catalogue to retreive a subset of record that satsify zero or more query criteria.
+This clause describes how to search a catalogue to retreive a subset of records that satsify zero or more query criteria.
 
 ==== Operation
 
@@ -318,36 +319,36 @@ supported at the `/collections/{collectionId}/items` endpoint.
 [cols="15,85",options="header"]
 |===
 |Parameter name |Description
-|bbox |A bounding box. If the spatial extent of the record intersects the specified bounding box then the record shall be presented in the response document.
-|datetime |A time instance or time period. If the temporal extent of the record intersects the specified data/time value then the record shall be presented in the response document.
-|limit |The number of records to be presented in a response document.
-|q |A comma-separated list of search terms. If any server-chosen text field in the record contains 1 or more of the terms listed then this records shall appear in the response set.
-|type |An equality predicate consistent of a comma-separated list of resource types.  Only records of the listed type shall appear in the resource set.
-|externalid |An equality predicate consistent of a comma-separated list of external resource identifiers. Only records with the specified external identifiers shall appear in the response set.
+|`bbox` |A bounding box. If the spatial extent of the record intersects the specified bounding box then the record shall be presented in the response document.
+|`datetime` |A time instance or time period. If the temporal extent of the record intersects the specified data/time value then the record shall be presented in the response document.
+|`limit` |The number of records to be presented in a response document.
+|`q` |A comma-separated list of search terms. If any server-chosen text field in the record contains 1 or more of the terms listed then this records shall appear in the response set.
+|`type` |An equality predicate consistent of a comma-separated list of resource types.  Only records of the listed type shall appear in the resource set.
+|`externalId` |An equality predicate consistent of a comma-separated list of external resource identifiers. Only records with the specified external identifiers shall appear in the response set.
 |===
 
-The query parameters https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`bbox`], https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`datetime`] and https://docs.ogc.org/DRAFTS/20-024.html#limit-parameter-requirements[`limit`] are inherited from API -Common.  All requirements and recommendations in API - Common regarding these parameters also apply for API - Records.
+The query parameters https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`bbox`], https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`datetime`] and https://docs.ogc.org/DRAFTS/20-024.html#limit-parameter-requirements[`limit`] are inherited from OGC API - Common.  All requirements and recommendations in OGC API - Common regarding these parameters also apply for this standard.
 
-The query parameters `q`, `type` and `externalid` are specific to API - Records.
+The query parameters `q`, `type` and `externalId` are specific to this standard.
 
 [[core-query-parameters-bbox]]
 ===== Parameter bbox
 
-The Bounding Box (bbox) parameter is defined in API - Common. The following requirement governs use of that parameter in API - Records.
+The Bounding Box (`bbox`) parameter is defined in OGC API - Common. The following requirement governs use of that parameter in this standard.
 
 include::requirements/core/REQ_query-param-bbox.adoc[]
 
 [[core-query-parameters-datetime]]
 ===== Parameter datetime
 
-The Date-Time (datetime) parameter is defined in API - Common. The following requirement governs use of that parameter in API - Records.
+The DateTime (`datetime`) parameter is defined in OGC API - Common. The following requirement governs use of that parameter in this standard.
 
 include::requirements/core/REQ_query-param-datetime.adoc[]
 
 [[core-query-parameters-limit]]
 ===== Parameter limit
 
-The limit parameter is defined in API - Common. The following requirement governs use of that parameter in API - Records.
+The limit (`limit`) parameter is defined in OGC API - Common. The following requirement governs use of that parameter in this standard.
 
 include::requirements/core/REQ_query-param-limit.adoc[]
 
@@ -404,8 +405,7 @@ include::recommendations/core/REC_record-collection-next-2.adoc[]
 
 include::recommendations/core/REC_record-collection-next-3.adoc[]
 
-This document does not mandate any specific implementation approach for the
-`next` links.
+This document does not mandate any specific implementation approach for `next` links.
 
 An implementation could use opaque links that are managed by the server. It is
 up to the server to determine how long these links can be de-referenced.
@@ -442,10 +442,10 @@ include::recommendations/core/PER_additional-properties.adoc[]
 [cols="20,5,55,20",options="header"]
 |===
 |Queryables |Requirement |Description |GeoJSON key
-|recordId |M |A unique record identifier assigned by the server. |id
-|recordCreated |O |The date this record was created in the server. |created
-|recordUpdated |O |The most recent date on which the record was changed. |updated
-|links |O |A list of links for navigating the API (e.g. link to previous or next pages; links to alternative representations, etc.) |links
+|recordId |M |A unique record identifier assigned by the server. |`id`
+|recordCreated |O |The date this record was created in the server. |`properties.recordCreated`
+|recordUpdated |O |The most recent date on which the record was changed. |`properties.recordUpdated`
+|links |O |A list of links for navigating the API (e.g. link to previous or next pages; links to alternative representations, etc.) |`links`
 |===
 
 [[core-queryables-resource-table]]
@@ -454,24 +454,23 @@ include::recommendations/core/PER_additional-properties.adoc[]
 [cols="20,5,55,20",options="header"]
 |===
 |Queryables |Requirement |Description |GeoJSON key
-|type |M |The nature or genre of the resource. |properties.type
-|title |M |A human-readable name given to the resource. |properties.title
-
-|description |O |A free-text description of the resource. |properties.description
-|keywords |O |A list of keywords or tag associated with the resource. |properties.keyword
-|keywordsCodespace |O |A reference to a controlled vocabulary used for the keywords property. |properties.keyword-codespace
-|language |O |This refers to the natural language used for textual values (i.e. titles, descriptions, etc) of a resource. |properties.language
-|externalId |O |An identifier for the resource assigned by an external entity. |properties.externalid
-|created |O |The date the resource was created. |properties.created
-|updated |O |The more recent date on which the resource was changed. |properties.updated
-|publisher |O |The entity making the resource available. |properties.publisher
-|themes |O |A knowledge orgnaization system used to classify the resource. |properties.themes
-|formats |O |A list of available distributions for the resource. |properties.formats
-|contactPoint |O |An entity to contact about the resource. |properties.contactpoint
-|license |O |A legal document under which the resource is made available. |properties.license
-|rights |O |A statement that concerns all rights not addressed by the license such as a copyright statement. |properties.rights
-|extent |O |The spatio-temporal coverage of the resource. |properties.extent
-|associations |O |A list of links for accessing the resource, links to other resources associated with this resource, etc. |properties.associations
+|type |M |The nature or genre of the resource. |`properties.type`
+|title |M |A human-readable name given to the resource. |`properties.title`
+|description |O |A free-text description of the resource. |`properties.description`
+|keywords |O |A list of keywords or tag associated with the resource. |`properties.keyword`
+|keywordsCodespace |O |A reference to a controlled vocabulary used for the keywords property. |`properties.keyword-codespace`
+|language |O |This refers to the natural language used for textual values (i.e. titles, descriptions, etc) of a resource. |`properties.language`
+|externalId |O |An identifier for the resource assigned by an external entity. |`properties.externalId`
+|created |O |The date the resource was created. |`properties.created`
+|updated |O |The more recent date on which the resource was changed. |`properties.updated`
+|publisher |O |The entity making the resource available. |`properties.publisher`
+|themes |O |A knowledge orgnaization system used to classify the resource. |`properties.themes`
+|formats |O |A list of available distributions for the resource. |`properties.formats`
+|contactPoint |O |An entity to contact about the resource. |`properties.contactpoint`
+|license |O |A legal document under which the resource is made available. |`properties.license`
+|rights |O |A statement that concerns all rights not addressed by the license such as a copyright statement. |`properties.rights`
+|extent |O |The spatio-temporal coverage of the resource. |`properties.extent`
+|associations |O |A list of links for accessing the resource, links to other resources associated with this resource, etc. |`properties.associations`
 |===
 
 The following YAML fragment defines the schema of a single record in a query response.
@@ -532,10 +531,10 @@ The links in a record could be (in this example represented as link headers):
 
 [source]
 ----
-Link: <http://data.example.org/collections/my_catalogue/items/record_123.json>; rel="self"; type="application/geo+json"
-Link: <http://data.example.org/collections/my_catalogue/items/record_123.html>; rel="alternate"; type="text/html"
-Link: <http://data.example.org/collections/my_catalogue.json>; rel="collection"; type="application/json"
-Link: <http://data.example.org/collections/my_catalogue.html>; rel="collection"; type="text/html"
+Link: <https://example.org/collections/mycat/items/record_123.json>; rel="self"; type="application/geo+json"
+Link: <https://example.org/collections/mycat/items/record_123.html>; rel="alternate"; type="text/html"
+Link: <https://example.org/collections/mycat.json>; rel="collection"; type="application/json"
+Link: <https://example.org/collections/mycat:html>; rel="collection"; type="text/html"
 ----
 ====
 
@@ -640,7 +639,7 @@ The return status codes described in <<status-codes>> do not cover all possible 
 
 include::recommendations/core/PER_additional-status-codes.adoc[]
 
-When a server encounters an error in the processing of a request, it may wish to include information in addition to the status code in the response. Since Web API interactions are often machine-to-machine, a machine-readable report would be prefered. <<rfc7807,IETF RFC 7807>> addresses this need by providing "Problem Details" response schemas for both JSON and XML.
+When a server encounters an error in the processing of a request, it may wish to include information in addition to the status code in the response. Since Web API interactions are often machine-to-machine, a machine-readable report is preferred. <<rfc7807,IETF RFC 7807>> addresses this need by providing "Problem Details" response schemas for both JSON and XML.
 
 include::recommendations/core/REC_problem-details.adoc[]
 

--- a/core/standard/clause_8_collections.adoc
+++ b/core/standard/clause_8_collections.adoc
@@ -11,24 +11,24 @@ OGC API - Records clients.
 
 The conformance class defines the following extensions:
 
-1. It extends the set of query parameters defined in the https://github.com/opengeospatial/oapi_common/blob/master/collections/clause_8_collections.adoc#11-collections-metadata[Collections Metadata] section to support the richer set of query parameters defined in the <<parameters-section,Parameters>> clause of this specification.
+1. It extends the set of query parameters defined in the https://docs.ogc.org/DRAFTS/20-024.html#collections-metadata[Collections Metadata] section to support the richer set of query parameters defined in the <<parameters-section,Parameters>> clause of this specification.
 
-2. It extends the schema of the collection information object defined in the https://github.com/opengeospatial/oapi_common/blob/master/collections/clause_8_collections.adoc#12-collection-information[Collection Information] clause of the https://github.com/opengeospatial/oapi_common/blob/master/core/OAPI_Common-Core.adoc[OGC API - Common - Part 2: Geospatial Data] extension to add additional keys/properties that are required by OGC API - Records.
+2. It extends the schema of the collection information object defined in the https://docs.ogc.org/DRAFTS/20-024.html#collection-description[Collection Description] clause of the https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Geospatial Data] extension to add additional keys/properties that are required by OGC API - Records.
 
 
 === Collections Metadata
 
-The https://github.com/opengeospatial/oapi_common/blob/master/collections/clause_8_collections.adoc#11-collections-metadata[Collections Metadata] clause of the https://github.com/opengeospatial/oapi_common/blob/master/core/OAPI_Common-Core.adoc[OGC API - Common - Part 2: Geospatial Data] extension defines the `bbox`, `datetime` and 'limit' query parameters for the `/collections` resource. 
+The https://docs.ogc.org/DRAFTS/20-024.html#collections-metadata[Collections Metadata] clause of the https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Geospatial Data] extension defines the `bbox`, `datetime` and 'limit' query parameters for the `/collections` resource. 
 
 include::requirements/collections/REQ_collections_query-params.adoc[]
 
-The collections metadata (i.e. HTTP GET on the `/collections` path) is defined in the https://github.com/opengeospatial/oapi_common/blob/master/collections/clause_8_collections.adoc#response[Collections Metadata] clause of the https://github.com/opengeospatial/oapi_common/blob/master/core/OAPI_Common-Core.adoc[OGC API - Common - Part 2: Geospatial Data] extension.  
+The collections metadata (i.e. HTTP GET on the `/collections` path) is defined in the https://docs.ogc.org/DRAFTS/20-024.html#_response[Collections Metadata] clause of the https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Geospatial Data] extension.  
 
 include::requirements/collections/REQ_collections_query-response.adoc[]
 
-=== Collection information
+=== Collection Description
 
-The collection information object is defined in the https://github.com/opengeospatial/oapi_common/blob/master/collections/clause_8_collections.adoc#12-collection-information[Collection Information] clause of the https://github.com/opengeospatial/oapi_common/blob/master/core/OAPI_Common-Core.adoc[OGC API - Common - Part 2: Geospatial Data] extension.
+The collection information object is defined in the https://docs.ogc.org/DRAFTS/20-024.html#collection-description[Collection Description] clause of the https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Geospatial Data] extension.
 
 The following table cross-walks the properties of the collection information
 object with the core queryables.
@@ -75,7 +75,7 @@ include::requirements/collections/REQ_collections_keywords.adoc[]
 
 include::recommendations/collections/REC_collections_additional-properties.adoc[]
 
-The collections metadata response is defined in the https://github.com/opengeospatial/oapi_common/blob/master/collections/clause_8_collections.adoc#response[Collections Metadata] clause on the https://github.com/opengeospatial/oapi_common/blob/master/core/OAPI_Common-Core.adoc[OGC API - Common - Part 2: Geospatial Data] extension.
+The collections metadata response is defined in the https://docs.ogc.org/DRAFTS/20-024.html#collection-metadata[Collections Metadata] clause on the https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Geospatial Data] extension.
 
 include::requirements/collections/REQ_collections-schema.adoc[]
 

--- a/core/standard/clause_9_sorting.adoc
+++ b/core/standard/clause_9_sorting.adoc
@@ -23,7 +23,7 @@ include::requirements/sorting/REQ_sortables-op.adoc[]
 include::requirements/sorting/REQ_sortables-success.adoc[]
 
 [[schema_sortables]]
-.link:http://fix.me/sortables.yaml[Schema for the list of sortables (sortables.yaml)]
+.link:http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/responses/Sortables.yaml[Schema for the list of sortables (Sortables.yaml)]
 [source,YAML]
 ----
 type: object
@@ -37,7 +37,7 @@ properties:
 ----
 
 [[schema_sortable]]
-.link:http://fix.me/sortable.yaml[Schema for a sortable description(sortable.yaml)]
+.link:http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/schemas/sortable.yaml[Schema for a sortable description(sortable.yaml)]
 [source,YAML]
 ----
 type: object
@@ -85,5 +85,5 @@ include::../examples/json/sortables.json[]
 .sortby Example of an ascending sort be extent (i.e. smaller area first)
 [source]
 ----
-.../collections/mycat/items?...&sortby=+extent&...
+.../collections/mycat/items?...&sortby=%2Bextent&...
 ----

--- a/core/standard/clause_9_sorting.adoc
+++ b/core/standard/clause_9_sorting.adoc
@@ -26,43 +26,14 @@ include::requirements/sorting/REQ_sortables-success.adoc[]
 .link:http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/responses/Sortables.yaml[Schema for the list of sortables (Sortables.yaml)]
 [source,YAML]
 ----
-type: object
-required:
-- sortables   
-properties:
-   sortables:
-      type: array
-      items:
-         $ref: sortable.yaml
+include::../openapi/responses/Sortables.yaml[]
 ----
 
 [[schema_sortable]]
 .link:http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/schemas/sortable.yaml[Schema for a sortable description(sortable.yaml)]
 [source,YAML]
 ----
-type: object
-required:
-   - id   
-   - type
-properties:
-   id:
-      description: the identifier/name for the sortable
-      type: string
-   title:
-      description: a human readable title for the sortable
-      type: string
-   description:
-      description: a human-readable narrative describing the sortable
-      type: string
-   language:
-      description: the language used for the title and description
-      type: string
-   links:
-      description: additional links, e.g. to documentation or to the schema of the values
-      type: array
-      items:
-         $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-features
-/master/core/openapi/ogcapi-features-1.yaml#/components/schemas/link'
+include::../openapi/schemas/sortable.yaml[]
 ----
 
 === Examples

--- a/core/standard/recommendations/opensearch/REC_param-geo-name.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-geo-name.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-geo-name*
-^|A |Servers SHOULD support the place name search parameter (`geo:name`) for the search operation (method: GET, path: /collections/{collectionId}/items).
+^|A |Servers SHOULD support the place name search parameter (`geo:name`) for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/opensearch/REC_param-geo-relation.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-geo-relation.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-geo-relation*
-^|A |Servers SHOULD support the geometry relation (`geo:relation`) parameter for the search operation (method: GET, path: /collections/{collectionId}/items).
+^|A |Servers SHOULD support the geometry relation (`geo:relation`) parameter for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/opensearch/REC_param-geometry.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-geometry.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-geometry*
-^|A |Servers SHOULD support the geometry (`geo:geometry`) parameter for the search operation (method: GET, path: /collections/{collectionId}/items).
+^|A |Servers SHOULD support the geometry (`geo:geometry`) parameter for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/opensearch/REC_param-language.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-language.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-language*
 
-Servers SHOULD support the language (`language`) parameter for the search operation (method: GET, path: /collections/{collectionId}/items).
+Servers SHOULD support the language (`language`) parameter for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/opensearch/REC_param-proximity.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-proximity.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-proximity*
-^|A |Servers SHOULD support the proximity parameters (`geo:lat`, `geo:lon`, `geo:radius`) for the search operation (method: GET, path: /collections/{collectionId}/items).
+^|A |Servers SHOULD support the proximity parameters (`geo:lat`, `geo:lon`, `geo:radius`) for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/opensearch/REC_param-startindex.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-startindex.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-startIndex*
-^|A |Servers SHOULD support the start index (`startIndex`) parameter for the search operation (method: GET, path: /collections/{collectionId}/items).
+^|A |Servers SHOULD support the start index (`startIndex`) parameter for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/opensearch/REC_param-startpage.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-startpage.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-startPage*
-^|A |Servers SHOULD support the start page (`startPage`) parameter for the search operation (method: GET, path: /collections/{collectionId}/items).
+^|A |Servers SHOULD support the start page (`startPage`) parameter for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/opensearch/REC_param-time-relation.adoc
+++ b/core/standard/recommendations/opensearch/REC_param-time-relation.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/opensearch/param-time-relation*
-^|A |Servers SHOULD support the geometry relation (`geo:relation`) parameter for the search operation (method: GET, path: /collections/{collectionId}/items).
+^|A |Servers SHOULD support the geometry relation (`geo:relation`) parameter for the search operation (method: GET, path: `/collections/{collectionId}/items`).
 |===

--- a/core/standard/recommendations/record-filter/REC_json-encoding.adoc
+++ b/core/standard/recommendations/record-filter/REC_json-encoding.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/record-filter/JSON-encoding*
-^|A |If a filter expression can be represented for its intended use as JSON, servers SHOULD consider supporting the http://docs.opengeospatial.org/DRAFTS/19-079.html#cql-json[CQL JSON] encoding.
+^|A |If a filter expression can be represented for its intended use as JSON, servers SHOULD consider supporting the https://docs.ogc.org/DRAFTS/19-079.html#cql-json[CQL JSON] encoding.
 |===

--- a/core/standard/recommendations/record-filter/REC_text-encoding.adoc
+++ b/core/standard/recommendations/record-filter/REC_text-encoding.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/record-filter/text-encoding*
-^|A |If a filter expression can be represented for its intended use as text, servers SHOULD consider supporting the http://docs.opengeospatial.org/DRAFTS/19-079.html#cql-text[CQL text] encoding.
+^|A |If a filter expression can be represented for its intended use as text, servers SHOULD consider supporting the https://docs.ogc.org/DRAFTS/19-079.html#cql-text[CQL text] encoding.
 |===

--- a/core/standard/requirements/atom/REQ_common-content.adoc
+++ b/core/standard/requirements/atom/REQ_common-content.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/atom/common-content*
-^|A |<<xml_content>> specifies the XML document root element that the server SHALL return in a `200`-response for each resource defined in http://docs.opengeospatial.org/DRAFTS/19-072.html[OGC API - Common - Part 1: Core] and http://docs.opengeospatial.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Collections].
+^|A |<<xml_content>> specifies the XML document root element that the server SHALL return in a `200`-response for each resource defined in https://docs.ogc.org/DRAFTS/19-072.html[OGC API - Common - Part 1: Core] and https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Collections].
 ^|B |The schema of all responses with a root element in the `core` namespace SHALL validate against the link:https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/xml/core.xsd[OGC API Records Core XML Schema].
 |===

--- a/core/standard/requirements/atom/REQ_common-content.adoc
+++ b/core/standard/requirements/atom/REQ_common-content.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/atom/common-content*
 ^|A |<<xml_content>> specifies the XML document root element that the server SHALL return in a `200`-response for each resource defined in https://docs.ogc.org/DRAFTS/19-072.html[OGC API - Common - Part 1: Core] and https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Collections].
-^|B |The schema of all responses with a root element in the `core` namespace SHALL validate against the link:https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/xml/core.xsd[OGC API Records Core XML Schema].
+^|B |The schema of all responses with a root element in the `core` namespace SHALL validate against the link:https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/xml/core.xsd[OGC API - Records Core XML Schema].
 |===

--- a/core/standard/requirements/atom/REQ_feed-extension-elements.adoc
+++ b/core/standard/requirements/atom/REQ_feed-extension-elements.adoc
@@ -2,8 +2,8 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/atom/feed-extension-elements*
-^|A |If a property `timeStamp` is included in the response, its value SHALL be reported using a XML element named `core:TimeStamp` as defined in the link:http://schemas.opengis.net/ogcapi/records/part1/1.0/xml/core.xsd[OGC API Records Core XML Schema].
+^|A |If a property `timeStamp` is included in the response, its value SHALL be reported using a XML element named `core:TimeStamp` as defined in the link:http://schemas.opengis.net/ogcapi/records/part1/1.0/xml/core.xsd[OGC API - Records Core XML Schema].
 ^|B |If included, the `core:TimeStamp` element is a https://tools.ietf.org/html/rfc4287#section-6.4.1[simple ATOM extension element] that SHALL be included as an immediate child of the `atom:feed` element.
-^|C |If a property `numberReturned` is included in the response, its value SHALL be reported using an XML element named `core:NumberReturned` as defined in the link:http://schemas.opengis.net/ogcapi/records/part1/1.0/xml/core.xsd[OGC API Records Core XML Schema].
+^|C |If a property `numberReturned` is included in the response, its value SHALL be reported using an XML element named `core:NumberReturned` as defined in the link:http://schemas.opengis.net/ogcapi/records/part1/1.0/xml/core.xsd[OGC API - Records Core XML Schema].
 ^|D |If included, the `core:NumberReturned` element is a https://tools.ietf.org/html/rfc4287#section-6.4.1[simple ATOM extension element] that SHALL be included as an immediate child of the `atom:feed` element.
 |===

--- a/core/standard/requirements/core/REQ_query-param-bbox.adoc
+++ b/core/standard/requirements/core/REQ_query-param-bbox.adoc
@@ -3,6 +3,6 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/param-bbox*
 ^|A |A Records API SHALL support the Bounding Box (bbox) parameter for the operation.
-^|B |Requests which include the Bounding Box parameter SHALL comply with API - Common requirement http://docs.opengeospatial.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-definition`].
-^|C |Responses to Bounding Box requests SHALL comply with API - Common requirement http://docs.opengeospatial.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-response`].
+^|B |Requests which include the Bounding Box parameter SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-definition`].
+^|C |Responses to Bounding Box requests SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-response`].
 |===

--- a/core/standard/requirements/core/REQ_query-param-bbox.adoc
+++ b/core/standard/requirements/core/REQ_query-param-bbox.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/param-bbox*
-^|A |A Records API SHALL support the Bounding Box (bbox) parameter for the operation.
-^|B |Requests which include the Bounding Box parameter SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-definition`].
-^|C |Responses to Bounding Box requests SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-response`].
+^|A |A Records API SHALL support the Bounding Box (`bbox`) parameter for the operation.
+^|B |Requests which include the Bounding Box parameter SHALL comply with OGC API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-definition`].
+^|C |Responses to Bounding Box requests SHALL comply with OGC API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#bbox-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-bbox-response`].
 |===

--- a/core/standard/requirements/core/REQ_query-param-datetime.adoc
+++ b/core/standard/requirements/core/REQ_query-param-datetime.adoc
@@ -3,6 +3,6 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/param-datetime*
 ^|A |A Records API SHALL support the Date-Time (datetime) parameter for the operation.
-^|B |Requests which include the Date-Time parameter SHALL comply with API - Common requirement http://docs.opengeospatial.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-definition`].
-^|C |Responses to Date-Time requests SHALL comply with API - Common requirement http://docs.opengeospatial.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-response`].
+^|B |Requests which include the Date-Time parameter SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-definition`].
+^|C |Responses to Date-Time requests SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-response`].
 |===

--- a/core/standard/requirements/core/REQ_query-param-datetime.adoc
+++ b/core/standard/requirements/core/REQ_query-param-datetime.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/param-datetime*
-^|A |A Records API SHALL support the Date-Time (datetime) parameter for the operation.
-^|B |Requests which include the Date-Time parameter SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-definition`].
-^|C |Responses to Date-Time requests SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-response`].
+^|A |A Records API SHALL support the DateTime (`datetime`) parameter for the operation.
+^|B |Requests which include the DateTime parameter SHALL comply with OGC API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-definition`].
+^|C |Responses to DateTime requests SHALL comply with OGC API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#datetime-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-time-response`].
 |===

--- a/core/standard/requirements/core/REQ_query-param-limit.adoc
+++ b/core/standard/requirements/core/REQ_query-param-limit.adoc
@@ -3,7 +3,7 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/param-limit*
 ^|A |A Records API SHALL support the Limit (limit) parameter for the operation.
-^|B |Requests which include the Limit parameter SHALL comply with API - Common requirement http://docs.opengeospatial.org/DRAFTS/20-024.html#limit-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-limit-definition`].
+^|B |Requests which include the Limit parameter SHALL comply with API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#limit-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-limit-definition`].
 ^|C |Responses to Limit requests SHALL comply with API - Common requirements:
-* http://docs.opengeospatial.org/DRAFTS/20-024.html#limit-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-limit-response`]
+* https://docs.ogc.org/DRAFTS/20-024.html#limit-parameter-requirements[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-limit-response`]
 |===

--- a/core/standard/requirements/core/REQ_query-param-list-delimiter.adoc
+++ b/core/standard/requirements/core/REQ_query-param-list-delimiter.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/query-param-list-delimiter* 
 ^|A |Parameters values containing lists SHOULD specify the delimiter to be used in the API definition.
-^|B |The default list item delimiter SHALL be the comma (",").
+^|B |The default list item delimiter SHALL be the comma ("`,`").
 |===

--- a/core/standard/requirements/core/REQ_query-param-value-boolean.adoc
+++ b/core/standard/requirements/core/REQ_query-param-value-boolean.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/query-param-value-boolean* 
-^|A |Boolean values shall be represented by the lowercase strings "true" and "false", representing Boolean true and false respectively.
+^|A |Boolean values shall be represented by the lowercase strings `true` and `false`, representing Boolean true and false respectively.
 |===

--- a/core/standard/requirements/core/REQ_query-param-value-decimal.adoc
+++ b/core/standard/requirements/core/REQ_query-param-value-decimal.adoc
@@ -4,8 +4,8 @@
 ^|*Requirement {counter:req-id}* |*/req/core/query-param-value-decimal* 
 ^|A |Decimal values SHALL be represented by a finite-length sequence of decimal digits separated by a period as a decimal indicator. 
 
-* An optional leading negative sign ("-") is allowed.
-* If the sign is omitted, positive ("+") is assumed. 
+* An optional leading negative sign ("`-`") is allowed.
+* If the sign is omitted, positive ("`+`") is assumed. 
 * Leading and trailing zeroes are optional. 
 * If the fractional part is zero, the period and following zero(es) can be omitted. 
 |===

--- a/core/standard/requirements/core/REQ_record-collection-media-type-default.adoc
+++ b/core/standard/requirements/core/REQ_record-collection-media-type-default.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/rc-mediatype-default*
-^|A |IF the `JSON` Conformance Class is advertised, then the default media type for content SHALL be JSON or GeoJSON.
-^|C |IF the `JSON` Conformance Class is not advertised, then the default media type for content SHALL be HTML. 
+^|A |If the `JSON` Conformance Class is advertised, then the default media type for content SHALL be JSON or GeoJSON.
+^|C |If the `JSON` Conformance Class is not advertised, then the default media type for content SHALL be HTML. 
 |===

--- a/core/standard/requirements/core/REQ_record-collection-op.adoc
+++ b/core/standard/requirements/core/REQ_record-collection-op.adoc
@@ -2,7 +2,7 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/core/rc-op*
-^|A |A Records API implementation SHALL comply with the API - Common requirement http://docs.opengeospatial.org/DRAFTS/20-024.html#_operation_3[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-op`].
-^|B |For API - Records, the API - Common http://docs.opengeospatial.org/DRAFTS/20-024.html#_operation_3[`/req/collections/rc-op`] requirement SHALL apply to collections where the value of the `itemType` property is specified as `record`.
+^|A |A Records API implementation SHALL comply with the API - Common requirement https://docs.ogc.org/DRAFTS/20-024.html#_operation_3[`http://www.opengis.net/spec/ogcapi_common-2/1.0/req/collections/rc-op`].
+^|B |For API - Records, the API - Common https://docs.ogc.org/DRAFTS/20-024.html#_operation_3[`/req/collections/rc-op`] requirement SHALL apply to collections where the value of the `itemType` property is specified as `record`.
 ^|C |The property `itemType` is each property in the resource <<collection-info-response,collections response>> (JSONPath: `$.collections[*].itemType`).
 |===

--- a/core/standard/requirements/record-filter/REQ_filter-crs-param.adoc
+++ b/core/standard/requirements/record-filter/REQ_filter-crs-param.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/record-filter/filter-crs-param*
 ^|Condition |Server implements <<OAFeat-2,OGC API - Features - Part 2: Coordinate Reference Systems by Reference>>
-^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter-crs` parameter as defined in https://docs.opengeospatial.org/DRAFTS/19-079.html#filter-filter-crs[Parameter filter-crs].
+^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter-crs` parameter as defined in https://docs.ogc.org/DRAFTS/19-079.html#filter-filter-crs[Parameter filter-crs].
 |===

--- a/core/standard/requirements/record-filter/REQ_filter-crs-param.adoc
+++ b/core/standard/requirements/record-filter/REQ_filter-crs-param.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/record-filter/filter-crs-param*
 ^|Condition |Server implements <<OAFeat-2,OGC API - Features - Part 2: Coordinate Reference Systems by Reference>>
-^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter-crs` parameter as defined in http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-filter-crs[Parameter filter-crs].
+^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter-crs` parameter as defined in https://docs.opengeospatial.org/DRAFTS/19-079.html#filter-filter-crs[Parameter filter-crs].
 |===

--- a/core/standard/requirements/record-filter/REQ_filter-lang-param.adoc
+++ b/core/standard/requirements/record-filter/REQ_filter-lang-param.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/record-filter/filter-lang-param*
-^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter-lang` parameter as defined in http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-lang-param[Parameter filter-lang].
+^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter-lang` parameter as defined in https://docs.ogc.org/DRAFTS/19-079.html#filter-lang-param[Parameter filter-lang].
 |===

--- a/core/standard/requirements/record-filter/REQ_filter-param.adoc
+++ b/core/standard/requirements/record-filter/REQ_filter-param.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/features-filter/filter-param*
-^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter` parameter as defined in http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-param[Parameter filter].
+^|A |The HTTP GET operation on the `/collections/{collectionId}/items` path SHALL support the `filter` parameter as defined in https://docs.ogc.org/DRAFTS/19-079.html#filter-param[Parameter filter].
 |===

--- a/core/xml/core.xsd
+++ b/core/xml/core.xsd
@@ -17,7 +17,7 @@
 
       Copyright (c) 2019 Open Geospatial Consortium.
       To obtain additional rights of use, visit
-      http://www.opengeospatial.org/legal/ .
+      https://www.ogc.org/legal/ .
       </xsd:documentation>
    </xsd:annotation>
    <!-- ==============================================================

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -3,4 +3,4 @@
 This directory is where extensions to the "OGC API - Records - Part 1: Core"
 specification should live.
 
-These are extensions that are within the charter of the SWG and are being actively worked on. **Proposed** extension should be create in [https://github.com/opengeospatial/ogcapi-records/tree/master/proposals](proposals) directory.
+These are extensions that are within the charter of the SWG and are being actively worked on. **Proposed** extensions should be created in the [proposals](https://github.com/opengeospatial/ogcapi-records/tree/master/proposals) directory.

--- a/extensions/collections/openapi/ogcapi-records-1.yaml
+++ b/extensions/collections/openapi/ogcapi-records-1.yaml
@@ -9,7 +9,7 @@ info:
     OGC API - Records - Part 1: Core 1.0 is an OGC Standard.
     Copyright (c) 2020 Open Geospatial Consortium.
     To obtain additional rights of use, visit
-    http://www.opengeospatial.org/legal/ .
+    https://www.ogc.org/legal/ .
 
     This document is also available on
     [OGC](http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/ogcapi-records-1.yaml).
@@ -19,7 +19,7 @@ info:
     email: pvretano@pvretano.com
   license:
     name: OGC License
-    url: 'http://www.opengeospatial.org/legal/'
+    url: 'https://www.ogc.org/legal/'
 components:
   parameters:
     bbox:

--- a/extensions/collections/standard/21-046.adoc
+++ b/extensions/collections/standard/21-046.adoc
@@ -41,7 +41,7 @@
 |===
 |*Copyright notice*
 |Copyright (C) 2020 Open Geospatial Consortium
-|To obtain additional rights of use, visit http://www.opengeospatial.org/legal/
+|To obtain additional rights of use, visit https://www.ogc.org/legal/
 |===
 
 [cols = "^", frame = "none"]

--- a/extensions/collections/standard/README.md
+++ b/extensions/collections/standard/README.md
@@ -9,7 +9,7 @@ This specification addresses only those parts of an API which are specific to Re
 
 The latest drafts of each standard in this repository are built daily (based on the configuration contained in the [asciidoctor.json](https://github.com/opengeospatial/ogcapi-records/blob/master/asciidoctor.json) file):
 
-* [Part 1: Core](http://docs.ogc.org/DRAFTS/20-004.html)
+* [Part 1: Core](https://docs.ogc.org/DRAFTS/20-004.html)
 
 To generate HTML and PDF representations of the standard yourself, asciidoctor is required.  To install:
 

--- a/extensions/collections/standard/clause_11_encodings.adoc
+++ b/extensions/collections/standard/clause_11_encodings.adoc
@@ -29,7 +29,7 @@ It is also necessary to advertise conformance with this Requirements Class.
 include::requirements/json/REQ_json-conformance.adoc[]
 
 [[schema_record]]
-.link:http://fix.me/record.yaml[Schema for an extended collection information object (extendedCollectionInfo.yaml)]
+.link:http://schemas.opengis.net/ogcapi/records/part2/1.0/openapi/schemas/extendedCollectionInfo.yaml[Schema for an extended collection information object (extendedCollectionInfo.yaml)]
 [source,YAML]
 ----
 include::../openapi/schemas/extendedCollectionInfo.yaml[]

--- a/extensions/collections/standard/clause_11_encodings.adoc
+++ b/extensions/collections/standard/clause_11_encodings.adoc
@@ -20,7 +20,7 @@ include::requirements/requirements_class_json.adoc[]
 This section covers the requirements inherited from the API - Common standard. Its scope includes responses for the following operations:
 
 * `{root}/collections`: Collections
-* `{root}/collections/{collectionid}`: Collection Information
+* `{root}/collections/{collectionId}`: Collection Information
 
 include::requirements/json/REQ_api-common.adoc[]
 
@@ -54,7 +54,7 @@ include::requirements/requirements_class_html.adoc[]
 This section covers the requirements inherited from the API - Common standard. Its scope includes responses for the following operations:
 
 * `{root}/collections`: Collections
-* `{root}/collections/{collectionid}`: Collection Information
+* `{root}/collections/{collectionId}`: Collection Information
 
 include::requirements/html/REQ_api-common.adoc[]
 
@@ -89,7 +89,7 @@ include::requirements/requirements_class_atom.adoc[]
 This section covers the requirements inherited from the API - Common standard. Its scope includes responses for the following operations:
 
 * `{root}/collections`: Collections
-* `{root}/collections/{collectionid}`: Collection Information
+* `{root}/collections/{collectionId}`: Collection Information
 
 It is necessary to advertise conformance with this Requirements Class.
 

--- a/extensions/collections/standard/clause_3_references.adoc
+++ b/extensions/collections/standard/clause_3_references.adoc
@@ -32,4 +32,4 @@ The following normative documents contain provisions that, through reference in 
 * W3C: W3C JSON-LD 1.0, A JSON-based Serialization for Linked Data. http://www.w3.org/TR/json-ld/, 2014
 * W3C: W3C JSON-LD 1.0 Processing Algorithms and API. http://www.w3.org/TR/json-ld-api, 2014
 * W3C: W3C RDF 1.1 Concepts and Abstract Syntax. https://www.w3.org/TR/2014/REC-rdf11-concepts-20140225/, 2014
-* [[OAFeat-3]] OGC 19-19-079: *OGC API - Features - Part 3: Filter and the Common Query Language (CQL)*, http://docs.opengeospatial.org/DRAFTS/19-079.html
+* [[OAFeat-3]] OGC 19-19-079: *OGC API - Features - Part 3: Filter and the Common Query Language (CQL)*, https://docs.ogc.org/DRAFTS/19-079.html

--- a/extensions/collections/standard/clause_4_terms_and_definitions.adoc
+++ b/extensions/collections/standard/clause_4_terms_and_definitions.adoc
@@ -22,7 +22,7 @@ represents an accessible form of a *dataset* (DCAT)
 EXAMPLE: a downloadable file, an RSS feed or a web service that provides the data.
 
 === Executable Test Suite (ETS)
-set of code (e.g. Java and CTL) that provides runtime tests for the assertions defined by the ATS. Test data required to do the tests are part of the ETS https://portal.opengeospatial.org/files/?artifact_id=55234[(OGC 08-134)]
+set of code (e.g. Java and CTL) that provides runtime tests for the assertions defined by the ATS. Test data required to do the tests are part of the ETS https://portal.ogc.org/files/?artifact_id=55234[(OGC 08-134)]
 
 === Record
 atomic unit of information of a catalogue that is used to provide information about a particular resource

--- a/extensions/collections/standard/clause_6_overview.adoc
+++ b/extensions/collections/standard/clause_6_overview.adoc
@@ -40,7 +40,7 @@ The Records API offers various levels of search capability of escalating complex
 * free text
 * equality predicates based on a subset of core queryables (e.g. by resource type, by external identifier)
 
-Finally extensions, such as the http://docs.opengeospatial.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filter and the Common Query Language (CQL)], may be used with Part 2 to support complex search capabilities using a rich set of logically connected search predicates where the user has full control over to query expression.
+Finally extensions, such as the https://docs.ogc.org/DRAFTS/19-079.html[OGC API - Features - Part 3: Filter and the Common Query Language (CQL)], may be used with Part 2 to support complex search capabilities using a rich set of logically connected search predicates where the user has full control over to query expression.
 
 [[dependencies-overview]]
 === Dependencies

--- a/extensions/collections/standard/clause_8_sorting.adoc
+++ b/extensions/collections/standard/clause_8_sorting.adoc
@@ -20,7 +20,7 @@ include::requirements/sorting/REQ_sortables-op.adoc[]
 include::requirements/sorting/REQ_sortables-success.adoc[]
 
 [[schema_sortables]]
-.link:http://fix.me/sortables.yaml[Schema for the list of sortables (sortables.yaml)]
+.link:http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/responses/Sortables.yaml[Schema for the list of sortables (Sortables.yaml)]
 [source,YAML]
 ----
 type: object
@@ -34,7 +34,7 @@ properties:
 ----
 
 [[schema_sortable]]
-.link:http://fix.me/sortable.yaml[Schema for a sortable description(sortable.yaml)]
+.link:http://schemas.opengis.net/ogcapi/records/part1/1.0/openapi/schemas/sortable.yaml[Schema for a sortable description(sortable.yaml)]
 [source,YAML]
 ----
 type: object

--- a/extensions/collections/standard/clause_9_cql.adoc
+++ b/extensions/collections/standard/clause_9_cql.adoc
@@ -6,13 +6,13 @@
 
 include::requirements/requirements_class_cql.adoc[]
 
-This clause defines the binding to the filter parameters defined in the http://docs.opengeospatial.org/DRAFTS/19-079.html#_requirements_class_filter[OGC API - Features - Part 3: Filter and the Common Query Language (CQL), Requirements Class "Filter"] clause.
+This clause defines the binding to the filter parameters defined in the https://docs.ogc.org/DRAFTS/19-079.html#_requirements_class_filter[OGC API - Features - Part 3: Filter and the Common Query Language (CQL), Requirements Class "Filter"] clause.
 
 === Collection info objects
 
 ==== Operation
 
-As specified in the ??? clause of OGC API Common, collection info objects are accessed using the HTTP GET method via the `/collections` path.  The following additional requirements bind the parameters http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-param[filter], http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-lang-param[filter-lang] and http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-filter-crs[filter-crs] to the GET operation on this path.
+As specified in the ??? clause of OGC API Common, collection info objects are accessed using the HTTP GET method via the `/collections` path.  The following additional requirements bind the parameters https://docs.ogc.org/DRAFTS/19-079.html#filter-param[filter], https://docs.ogc.org/DRAFTS/19-079.html#filter-lang-param[filter-lang] and https://docs.ogc.org/DRAFTS/19-079.html#filter-filter-crs[filter-crs] to the GET operation on this path.
 
 include::requirements/cql/REQ_filter-param.adoc[]
 
@@ -47,7 +47,7 @@ Links can be added to the following sections in an extended collection info obje
 . the <<query-response,links>> section.
 . the <<query-response,associations>> section.
 
-The schema for links added to the <<query-response,links>> and <<query-response,associations>> sections in based on https://tools.ietf.org/html/rfc8288[RFC 8288] and is described in http://docs.opengeospatial.org/DRAFTS/19-072.html#link-relation-conventions[OGC API - Common - Part 1: Core] and http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml[OGC API - Features - Part 1: Core].
+The schema for links added to the <<query-response,links>> and <<query-response,associations>> sections in based on https://tools.ietf.org/html/rfc8288[RFC 8288] and is described in https://docs.ogc.org/DRAFTS/19-072.html#link-relation-conventions[OGC API - Common - Part 1: Core] and http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml[OGC API - Features - Part 1: Core].
 
 Links added directly to the collection info object can be added using the following patterns:
 

--- a/extensions/collections/standard/recommendations/cql/REC_json-encoding.adoc
+++ b/extensions/collections/standard/recommendations/cql/REC_json-encoding.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/record-filter/JSON-encoding*
-^|A |If a filter expression can be represented for its intended use as JSON, servers SHOULD consider supporting the http://docs.opengeospatial.org/DRAFTS/19-079.html#cql-json[CQL JSON] encoding.
+^|A |If a filter expression can be represented for its intended use as JSON, servers SHOULD consider supporting the https://docs.ogc.org/DRAFTS/19-079.html#cql-json[CQL JSON] encoding.
 |===

--- a/extensions/collections/standard/recommendations/cql/REC_text-encoding.adoc
+++ b/extensions/collections/standard/recommendations/cql/REC_text-encoding.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/record-filter/text-encoding*
-^|A |If a filter expression can be represented for its intended use as text, servers SHOULD consider supporting the http://docs.opengeospatial.org/DRAFTS/19-079.html#cql-text[CQL text] encoding.
+^|A |If a filter expression can be represented for its intended use as text, servers SHOULD consider supporting the https://docs.ogc.org/DRAFTS/19-079.html#cql-text[CQL text] encoding.
 |===

--- a/extensions/collections/standard/requirements/atom/REQ_common-content.adoc
+++ b/extensions/collections/standard/requirements/atom/REQ_common-content.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/atom/common-content*
-^|A |<<xml_content>> specifies the XML document root element that the server SHALL return in a `200`-response for each resource defined in http://docs.opengeospatial.org/DRAFTS/19-072.html[OGC API - Common - Part 1: Core] and http://docs.opengeospatial.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Collections].
+^|A |<<xml_content>> specifies the XML document root element that the server SHALL return in a `200`-response for each resource defined in https://docs.ogc.org/DRAFTS/19-072.html[OGC API - Common - Part 1: Core] and https://docs.ogc.org/DRAFTS/20-024.html[OGC API - Common - Part 2: Collections].
 ^|B |The schema of all responses with a root element in the `core` namespace SHALL validate against the link:http://schemas.opengis.net/ogcapi/records/part1/1.0/xml/core.xsd[OGC API Records Core XML Schema].
 |===

--- a/extensions/collections/standard/requirements/cql/REQ_filter-crs-param.adoc
+++ b/extensions/collections/standard/requirements/cql/REQ_filter-crs-param.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql/filter-crs-param*
 ^|Condition |Server implements <<OAFeat-2,OGC API - Features - Part 2: Coordinate Reference Systems by Reference>>
-^|A |The HTTP GET operation on the `/collections` path SHALL support the `filter-crs` parameter as defined in http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-filter-crs[Parameter filter-crs].
+^|A |The HTTP GET operation on the `/collections` path SHALL support the `filter-crs` parameter as defined in https://docs.ogc.org/DRAFTS/19-079.html#filter-filter-crs[Parameter filter-crs].
 |===

--- a/extensions/collections/standard/requirements/cql/REQ_filter-lang-param.adoc
+++ b/extensions/collections/standard/requirements/cql/REQ_filter-lang-param.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/cql/filter-lang-param*
-^|A |The HTTP GET operation on the `/collections` path SHALL support the `filter-lang` parameter as defined in http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-lang-param[Parameter filter-lang].
+^|A |The HTTP GET operation on the `/collections` path SHALL support the `filter-lang` parameter as defined in https://docs.ogc.org/DRAFTS/19-079.html#filter-lang-param[Parameter filter-lang].
 |===

--- a/extensions/collections/standard/requirements/cql/REQ_filter-param.adoc
+++ b/extensions/collections/standard/requirements/cql/REQ_filter-param.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/features-filter/filter-param*
-^|A |The HTTP GET operation on the `/collections` path SHALL support the `filter` parameter as defined in http://docs.opengeospatial.org/DRAFTS/19-079.html#filter-param[Parameter filter].
+^|A |The HTTP GET operation on the `/collections` path SHALL support the `filter` parameter as defined in https://docs.ogc.org/DRAFTS/19-079.html#filter-param[Parameter filter].
 |===

--- a/implementations.md
+++ b/implementations.md
@@ -110,7 +110,7 @@ Single record:
 
 ## Esri Inc
 
-This Esri Geoportal Server 2.6.4 [public sandbox](http://geoss.esri.com/geoportal_264) has now been extended with a work-in-progress implementation of the OGC Records API.
+This Esri Geoportal Server 2.6.4 [public sandbox](https://geoss.esri.com/geoportal_264) has now been extended with a work-in-progress implementation of the OGC Records API.
 
 Landing page:
 

--- a/resources.md
+++ b/resources.md
@@ -17,17 +17,17 @@ The following set of resource are taking for the list of issues in github.
 
 ## Standard identifiers for resources
 
-* https://portal.opengeospatial.org/files/?artifact_id=58896&version=1
+* https://portal.ogc.org/files/?artifact_id=58896&version=1
 * https://docs.ogc.org/per/16-043.html
 * https://github.com/OSGeo/Cat-Interop/LinkPropertyLookupTable.csv
 
 ## OpenSearch Geo
 
-* https://portal.opengeospatial.org/files/?artifact_id=56866
+* https://portal.ogc.org/files/?artifact_id=56866
 
 ## OGC OpenSearch Extension for Earth Observation (OpenSearch-EO)
 
-* https://portal.opengeospatial.org/files/?artifact_id=73994
+* https://portal.ogc.org/files/?artifact_id=73994
 
 ## Common Query Language (CQL)
 

--- a/resources.md
+++ b/resources.md
@@ -18,7 +18,7 @@ The following set of resource are taking for the list of issues in github.
 ## Standard identifiers for resources
 
 * https://portal.opengeospatial.org/files/?artifact_id=58896&version=1
-* http://docs.opengeospatial.org/per/16-043.html
+* https://docs.ogc.org/per/16-043.html
 * https://github.com/OSGeo/Cat-Interop/LinkPropertyLookupTable.csv
 
 ## OpenSearch Geo
@@ -35,5 +35,5 @@ The following set of resource are taking for the list of issues in github.
 
 ## Testbed-12 Semantic Portrayal, Registry and Mediation Engineering Report
 
-* http://docs.opengeospatial.org/per/16-059.html#_semantic_registry_information_model_srim_2
+* https://docs.ogc.org/per/16-059.html#_semantic_registry_information_model_srim_2
 

--- a/template/standard/19-xxx.adoc
+++ b/template/standard/19-xxx.adoc
@@ -31,7 +31,7 @@
 |Publication Date:  <yyyy-mm-dd>
 |External identifier of this OGC(R) document: http://www.opengis.net/doc/IS/ogcapi-features-n/1.0
 |Internal reference number of this OGC(R) document:    19-xxx
-|Version: link:http://docs.opengeospatial.org/DRAFTS/19-xxx.html[1.0.0-SNAPSHOT (Editor's draft)]
+|Version: link:https://docs.ogc.org/DRAFTS/19-xxx.html[1.0.0-SNAPSHOT (Editor's draft)]
 |Latest Published Draft: n/a
 |Category: OGC(R) Implementation Specification
 |Editors: TBD

--- a/template/standard/19-xxx.adoc
+++ b/template/standard/19-xxx.adoc
@@ -46,7 +46,7 @@
 |===
 |*Copyright notice*
 |Copyright (C) 2019 Open Geospatial Consortium
-|To obtain additional rights of use, visit http://www.opengeospatial.org/legal/
+|To obtain additional rights of use, visit https://www.ogc.org/legal/
 |===
 
 [cols = "^", frame = "none"]

--- a/template/standard/clause_3_references.adoc
+++ b/template/standard/clause_3_references.adoc
@@ -1,4 +1,4 @@
 == References
 The following normative documents contain provisions that, through reference in this text, constitute provisions of this document. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. For undated references, the latest edition of the normative document referred to applies.
 
-* [[OAFeat-1]] Portele, C., Vretanos, P.: OGC 17-069r2, *OGC API - Features - Part 1: Core*, http://example.com/fixme
+* [[OAFeat-1]] Portele, C., Vretanos, P.: OGC 17-069r2, *OGC API - Features - Part 1: Core*, https://docs.ogc.org/is/17-069r3/17-069r3.html

--- a/template/xml/core.xsd
+++ b/template/xml/core.xsd
@@ -13,7 +13,7 @@
 
       Copyright (c) 2019 Open Geospatial Consortium.
       To obtain additional rights of use, visit
-      http://www.opengeospatial.org/legal/ .
+      https://www.ogc.org/legal/ .
       </xsd:documentation>
    </xsd:annotation>
    <!-- ==============================================================


### PR DESCRIPTION
- changed relevant URLs to HTTPS
- added (to be) links to schema refs on http://schemas.opengis.net
- updated OGC URLs to ogc.org
- updated some YAML/JSON examples to point to actual files
- various editorial updates
- see "Record Schema" updates (6.2)

