### PR TITLE
add Annex on resource types (#26)

### DIFF
--- a/core/standard/20-004.adoc
+++ b/core/standard/20-004.adoc
@@ -123,6 +123,8 @@ include::annex_common.adoc[]
 
 include::annex_ats.adoc[]
 
+include::annex_resource_types.adoc[]
+
 include::annex_bibliography.adoc[]
 
 include::annex_history.adoc[]

--- a/core/standard/annex_common.adoc
+++ b/core/standard/annex_common.adoc
@@ -6,7 +6,7 @@
 [[common-overview]]
 === Overview
 
-This annex describe the components of the OGC API Records that are derived for OGC API Common.
+This annex describes the components of the OGC API Records that are derived for OGC API Common.
 
 [[core-dependencies-section]]
 === Dependencies

--- a/core/standard/annex_resource_types.adoc
+++ b/core/standard/annex_resource_types.adoc
@@ -1,0 +1,17 @@
+[appendix]
+:appendix-caption: Annex
+[[annex_resource_types]]
+== Common resource types (Informative)
+
+[[common_resource_types-overview]]
+=== Overview
+
+This annex describes commonly used codelists and identifiers for OGC resource types when qualifying resources via the record
+schema's `properties.type` property.  Please note that these codelists and identifiers are NOT normative.  For information
+communities wishing to further identify, it is suggested that a specification extension be developed to meet those
+requirements.
+
+* ISO 19115:2003: https://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml (`MD_ScopeCode`)
+* ISO 19115-1:2014: https://github.com/ISO-TC211/XML/blob/master/schemas.isotc211.org/19115/resources/Codelist/cat/codelists.xml (`MD_ScopeCode`)
+* OSGeo Catalogue Interoperability Group link types: https://github.com/OSGeo/Cat-Interop/blob/master/LinkPropertyLookupTable.csv
+* Service types from the OGC Naming Authority: http://www.opengis.net/def/serviceType


### PR DESCRIPTION
Addresses #26.  Note that there are pointers to codelists (vs. listing out all the actual types as examples).  I went this way given it would be confusing to have numerous examples of how to say a link is a WMS, for example, from the various codelists.