### PR TITLE
qualify default sort behaviour in OpenAPI parameter def

### DIFF
--- a/core/openapi/parameters/sortby.yaml
+++ b/core/openapi/parameters/sortby.yaml
@@ -2,9 +2,11 @@ name: sortby
 in: query
 description: |-
   Specifies a comma-separated list of property names by which the response shall
-  be sorted.  If the property name is preceeded by a plus (+) sign it inidicates
-  an ascending sort for that property.  If the property name is preceeded by a
-  minus (-) sigh it inidicates a descending sort for that property.
+  be sorted.  If the property name is preceded by a plus (+) sign it indicates
+  an ascending sort for that property.  If the property name is preceded by a
+  minus (-) sign it indicates a descending sort for that property.  If the
+  property is not preceded by a plus or minus, then the default sort order
+  implied is ascending (+).
 required: false
 schema:
   type: array

--- a/core/standard/clause_14_sorting.adoc
+++ b/core/standard/clause_14_sorting.adoc
@@ -14,7 +14,7 @@ The `Sorting` Requirements Class defines the requirements for specifying how rec
 include::requirements/sorting/REQ_sortby-definition.adoc[]
 
 NOTE: The core definition of the `sortby` parameter only defines a single directive that controls the sort order of the corresponding property.  It is anticipated extensions would add additional search facets such as directives for:
-handling missing values; specifying a high value indicating that the corresponding property be sorted as if it were the highest possible value; specifying a low value indicating that the corresponding property be sorted as if it were the lowest possible value; allowing records to be omitted from the result set based on their sort order; specify a fixed value  and a fixed value that sorts the corresponding property as if it were the specified fixed value.
+handling missing values; specifying a high value indicating that the corresponding property be sorted as if it were the highest possible value; specifying a low value indicating that the corresponding property be sorted as if it were the lowest possible value; allowing records to be omitted from the result set based on their sort order; specify a fixed value and a fixed value that sorts the corresponding property as if it were the specified fixed value.
 
 include::requirements/sorting/REQ_sortby-response.adoc[]
 


### PR DESCRIPTION
- adds extra text to `core/openapi/parameters/sortby.yaml` to clarify default sort behaviour
- removes extra space in `core/standard/clause_14_sorting.adoc`