### PR TITLE
remove additionalProperties given default is true

### DIFF
--- a/core/openapi/schemas/recordGeoJSON.yaml
+++ b/core/openapi/schemas/recordGeoJSON.yaml
@@ -158,7 +158,6 @@ properties:
           links to other resources associated with this resource.
         items:
           $ref: common/link.yaml
-      additionalProperties: true
   links:
     type: array
     description:

--- a/core/openapi/schemas/recordGeoJSON.yaml
+++ b/core/openapi/schemas/recordGeoJSON.yaml
@@ -146,7 +146,7 @@ properties:
       rights:
         type: string
         description:
-          A statement that concerns all rights not addresses by the license
+          A statement that concerns all rights not addressed by the license
           such as a copyright statement.
       extent:
         $ref: common/extent.yaml


### PR DESCRIPTION
This PR removes `additionalProperties` from the record GeoJSON schema given the implicit default is true in JSON Schema (REF: `/per/core/additional-properties-record`).

If we want to make `additionalProperties: true` (explicitly) in the schema I can update this PR to simply fix the indentation issue.