### PR TITLE
fix properties.externalIds definition

### DIFF
--- a/core/openapi/schemas/recordGeoJSON.yaml
+++ b/core/openapi/schemas/recordGeoJSON.yaml
@@ -98,9 +98,9 @@ properties:
                 organization system from which the external identifier was
                 obtained.  It is recommended that the identifier be a
                 resolvable URI.
-              value:
-                type: string
-                description: The value of the identifier.
+            value:
+              type: string
+              description: The value of the identifier.
           required:
             - value
       created:


### PR DESCRIPTION
Fixes schema definition for `properties.externalIds` (`value` should be a sibling of `scheme`).