### PR TITLE
Add organization/affiliation property in providers object

### DIFF
--- a/core/openapi/schemas/party.yaml
+++ b/core/openapi/schemas/party.yaml
@@ -30,6 +30,9 @@ oneOf:
       positionName:
         type: string
         description: Role or position of the responsible person.
+      organization:
+        type: string
+        description: Affiliation of the individual.
       logo:
         $ref: common/link.yaml
         description: Graphic identifying a party


### PR DESCRIPTION
The optional providers object in record is missing an affiliation/organization name property.
We do state that the required property `name` can also include the organization name, but it does not cover the affiliation case for the individual.
