### PR TITLE
Add a conformsTo member to the collection level.

### DIFF
--- a/core/openapi/schemas/catalogue.yaml
+++ b/core/openapi/schemas/catalogue.yaml
@@ -6,6 +6,13 @@ allOf:
     - itemType
     - type
   properties:
+    conformsTo:
+      description:
+        If all records of the catalogue conform to same set of
+        extensions/conformance classes then this member can be
+        used to advertise that fact rather than copying this 
+        information into each record.
+      $ref: common/confClasses.yaml#/properties/conformsTo
     created:
       type: string
       description:

--- a/core/standard/clause_2_conformance.adoc
+++ b/core/standard/clause_2_conformance.adoc
@@ -5,9 +5,34 @@
 
 Conformance with this standard shall be checked using the tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to claim conformance, are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.
 
-The standardization targets of all conformance classes are "Web APIs".
+The standardization target of the conformance classes:
 
-OGC API - Common provides a common foundation for OGC API standards. Therefore, this standard should be viewed as an extension to OGC API - Common. Conformance to this standard requires demonstrated conformance to the applicable Conformance Classes of OGC API - Common.
+* <<clause-records-api,Records API>>
+* <<clause-sorting,Sorting>>
+* <<clause-cql-filter,Filtering using the Common Query Language (CQL2)>>
+* <<clause-autodiscovery,Autodiscovery>>
+
+is "Web APIs".
+
+The standardization target of the conformance classes:
+
+* <<clause-record-core,Record Core>>
+* <<clause-record-collection,Record collection>>
+
+is "Document model".
+
+The standardization target of the conformance classes:
+
+* <<requirements-class-geojson-clause,JSON-Record>>
+* <<requirements-class-html-clause,HTML-Record>>
+
+is "Document encoding".
+
+https://docs.ogc.org/is/19-072/19-072.html[OGC API - Common] provides a common foundation for OGC API standards. Therefore, this standard should be viewed as an extension to OGC API - Common. Conformance to this standard requires demonstrated conformance to the applicable Conformance Classes of http://docs.ogc.org/DRAFTS/19-072.html#_conformance[OGC API - Common].
+
+NOTE: Should we remove this statement about Common?  Records is really an extension of Features and so the reference to Features conformance should be sufficient.  Features should then reference common ... but it does not currently do so.
+
+https://docs.opengeospatial.org/is/17-069r4/17-069r4.html[OGC API - Features] provides a common foundation for OGC API standards for feature access. Therefore, this standard should also be viewed as an extension to OGC API - Features. Conformance to this standard requires demonstrated conformance to the applicable Conformance Classes of https://docs.opengeospatial.org/is/17-069r4/17-069r4.html#_conformance[OGC API - Features].
 
 The Conformance Classes implemented by an API are advertised through the <<conformance-classes,`/conformance`>> path on the <<landing-page,landing page>>. Each Conformance Class has an associated Requirements Class. The Requirements Classes define the functional requirements which will be tested through the associated Conformance Class.
 

--- a/core/standard/clause_7_record.adoc
+++ b/core/standard/clause_7_record.adoc
@@ -39,6 +39,7 @@ Other encoding are allowed but are not described in this document.
 |recordId |**required** |A unique record identifier assigned by the server. |id
 |created |optional |The date this record was created in the server. |properties.created
 |updated |optional |The most recent date on which the record was changed. |properties.updated
+|conformsTo |optional |The extensions/conformance classes used in this record. |conformsTo
 |===
 
 [#core-queryables-resource-table,reftext='{table-caption} {counter:table-num}']
@@ -47,7 +48,7 @@ Other encoding are allowed but are not described in this document.
 |===
 |Queryables |Requirement |Description |GeoJSON key
 |geometry |**required** |A geometry associated with the resource that is used for discovery.  Can be null if there is no associated geometry. |geometry
-|time |**required** |The temporal extent of the resource. Can be null is there is not associated temporal extent. |time
+|time |**required** |The temporal extent of the resource. Can be null if there is no associated temporal extent. |time
 |type |**required** |The nature or genre of the resource. |properties.type
 |title |**required** |A human-readable name given to the resource. |properties.title
 |description |optional |A free-text description of the resource. |properties.description
@@ -65,6 +66,13 @@ Other encoding are allowed but are not described in this document.
 include::requirements/record-core/REQ_mandatory-queryables-record.adoc[]
 
 include::recommendations/record-core/PER_additional-queryables-record.adoc[]
+
+[[sc_record_extensions]]
+==== Record extensions
+
+In tables <<core-queryables-record-table>> and <<core-queryables-resource-table>> this standard defines a core set of properties for describing discoverable resources.  It is anticipated that this core set of properties will be extended to suite specific use cases or requirements.  For example, a catalogue record may be extended to include additional properties from the https://semiceu.github.io/GeoDCAT-AP/releases/[GeoDCAT] vocabulary.  The fact that a catalogue record has been extended in this way can be advertised using the `conformsTo` member.  The `conformsTo` member is a list of URIs that identify each extension used in a record.  This specification does not define the specific URIs that are used to identify a specific extension; it simply provides a place where these identifiers can be listed.
+
+In the case where all the records of a catalogue use the same set of extensions, and to prevent unnecessary duplication, there is also a `conformsTo` member at the https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/catalogue.yaml[collection or catalogue level] that may be used to declare which extensions are used in all records of the catalogue.  Extensions listed at the catalogue and record levels are cumulative.
 
 [[sc_keywords_and_themes]]
 ==== Keywords and Themes

--- a/core/standard/requirements/requirements_class_geojson.adoc
+++ b/core/standard/requirements/requirements_class_geojson.adoc
@@ -3,7 +3,7 @@
 |===
 2+|*Requirements Class*
 2+|http://www.opengis.net/spec/ogcapi-records-1/1.0/req/geojson
-|Target type |Web API
+|Target type |Document encoding
 |Dependency |<<rfc8259,IETF RFC 8259: The JavaScript Object Notation (JSON) Data Interchange Format>>
 |Dependency |<<jschema, JSON Schema>>
 |Dependency |<<rfc7946,GeoJSON>>

--- a/core/standard/requirements/requirements_class_html.adoc
+++ b/core/standard/requirements/requirements_class_html.adoc
@@ -3,7 +3,7 @@
 |===
 2+|*Requirements Class*
 2+|http://www.opengis.net/spec/ogcapi-records-1/1.0/req/html
-|Target type |Web API
+|Target type |Document encoding
 |Dependency |http://www.w3.org/TR/html5/[HTML5]
 |Pre-conditions |
 1) The API advertises conformance to the HTML Conformance Class +

--- a/core/standard/requirements/requirements_class_record-collection.adoc
+++ b/core/standard/requirements/requirements_class_record-collection.adoc
@@ -3,6 +3,6 @@
 |===
 2+|*Requirements Class*
 2+|http://www.opengis.net/spec/ogcapi-records-1/1.0/req/record-collection
-|Target type |Web API
+|Target type |Document model
 |Dependency |http://docs.opengeospatial.org/DRAFTS/20-024.html#collection-resource-definition-section[Collection Resource Definition]
 |===

--- a/core/standard/requirements/requirements_class_record-core.adoc
+++ b/core/standard/requirements/requirements_class_record-core.adoc
@@ -3,7 +3,7 @@
 |===
 2+|*Requirements Class*
 2+|http://www.opengis.net/spec/ogcapi-records-1/1.0/req/record-core
-|Target type |Web API
+|Target type |Document model
 |Dependency |<<rc_html,HTML>>
 |Dependency |<<rc_json,JSON or GeoJSON>>
 |===


### PR DESCRIPTION
This `conformsTo` member at the collection level allows extensions used in all catalogue records to be declared without having to repeat this information in every record.
Resolves issue #215.