### PR TITLE
Fix openapi Sortables response object

### DIFF
--- a/core/openapi/ogcapi-records-1.yaml
+++ b/core/openapi/ogcapi-records-1.yaml
@@ -918,9 +918,14 @@ components:
           schema:
             type: string
     Sortables:
-      type: array
-      items:
-        $ref: "#/components/schemas/sortable"
+      description: |-
+        Fetch the list of sortable properties.
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/sortable"
     OpenSearchDescriptionDocument:
       description: |-
         description document for OpenSearch clients


### PR DESCRIPTION
While validating the [openapi specification](https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/ogcapi-records-1.yaml) in swagger, I figured out that there were an issue with the Sortables definition.

Seems that the openapi 3.0 does not handle this kind of definition object.