### PR TITLE
Figuring out which knowledge system used in a catalogue.

### DIFF
--- a/core/openapi/schemas/theme.yaml
+++ b/core/openapi/schemas/theme.yaml
@@ -6,9 +6,9 @@ properties:
   concepts:
     type: array
     description:
-      One or more entity/concept identifers from this knowledge
-      system. it is recommended that a resolvable URI be used
-      for each entity/concept identifier.
+      One or more entity/concept identifiers from this knowledge
+      system. it is recommended that a resolvable URI be used for
+      each entity/concept identifier.
     minItems: 1
     items:
       type: object
@@ -33,4 +33,11 @@ properties:
     description:
       An identifier for the knowledge organization system used
       to classify the resource.  It is recommended that the
-      identifier be a resolvable URI.
+      identifier be a resolvable URI.  The list of schemes used
+      in a searchable catalogue can be determined by inspecting
+      the server's OpenAPI document or, if the server implements
+      CQL2, by exposing a queryable (e.g. named `scheme`) and
+      enumerating the list of schemes in the queryable's schema
+      definition.
+
+

--- a/core/standard/clause_7_record.adoc
+++ b/core/standard/clause_7_record.adoc
@@ -101,10 +101,11 @@ include::requirements/record-core/REQ_time-zone.adoc[]
 [[sc_keywords_and_themes]]
 ==== Keywords and Themes
 
-A record allows for one ``properties.keywords`` and one to many ``properties.themes``
-properties.  The following provides an example of using keywords for free
-form terms (e.g. tags) as well as themes to articulate terms from formal
-vocabularies or classification systems.
+A record allows for one `properties.keywords` and zero to many `properties.themes` properties.  Keywords are free form terms or tags associated with the resource(s) that the record describes.  Themes are concepts associated with the resource(s) that a record describes taken from one or more formal knowledge organization systems or schemes.  The list of knowledge organization systems or schemes used in a <<clause-searchable-catalogue,searchable>> or <<clause-local-resources-catalogue,local resources>> catalogue can be determined by inspecting the server's OpenAPI document or, if the server implements CQL2, by exposing a queryable (e.g. named `scheme`) and enumerating the list of schemes used in the queryable's schema definition.
+
+include::recommendations/record-core/REC_record-keywords-themes.adoc[]
+
+The following provides an example of using keywords for free form terms (e.g. tags) as well as themes to articulate terms from formal vocabularies or classification systems.
 
 [#keywords-themes-example,reftext=`Keywords and themes Example`]
 .Keywords and themes Example
@@ -112,11 +113,6 @@ vocabularies or classification systems.
 ----
 include::../examples/json/keywords-themes.json[]
 ----
-
-The following recommendations provide clarification on where and how to use
-these properties in a record.
-
-include::recommendations/record-core/REC_record-keywords-themes.adoc[]
 
 [[sc_contacts]]
 ==== Contacts

--- a/core/standard/recommendations/record-core/REC_record-keywords-themes.adoc
+++ b/core/standard/recommendations/record-core/REC_record-keywords-themes.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/record-core/keywords-themes*
-^|A |Implementations SHOULD use the record `properties.keywords` property to provide free-form keywords associated with the current record.
-^|B |Implementations SHOULD use the record `properties.themes` property to enumerate 1..n objects of concepts and their respective knowledge organization system/controlled vocabulary associated with the current record.
+^|A |Implementations SHOULD use the record `properties.keywords` property to provide free-form terms or tags associated with the resource(s) described by the current record.
+^|B |Implementations SHOULD use the record `properties.themes` property to enumerate 1..n concepts, and their respective knowledge organization system/controlled vocabulary, associated with the resource(s) descrtibed by the current record.
 |===


### PR DESCRIPTION
Provides informative text about how a server that implements a searchable or local resource catalogue might be interogated to figure out which list of knowledge systems are being in order to, for example, create pick lists.  

Closes #181 