### PR TITLE
Enforce the logo requirements

### DIFF
--- a/core/openapi/schemas/contact.yaml
+++ b/core/openapi/schemas/contact.yaml
@@ -26,10 +26,18 @@ properties:
       case of an organization, the name property should be used and this
       property is not to be used.
   logo:
-    $ref: common/link.yaml
     description:
       Graphic identifying a contact. The link relation should be `icon`
       and the media type should be an image media type.
+    allOf:
+      - $ref: common/link.yaml
+      - type: object
+        required:
+          - rel
+          - type
+        properties:
+          rel:
+            const: "icon"
   phones:
     type: array
     description: Telephone numbers at which contact can be made.

--- a/core/openapi/schemas/contact.yaml
+++ b/core/openapi/schemas/contact.yaml
@@ -99,7 +99,11 @@ properties:
     type: array
     description: On-line information about the contact.
     items:
-      $ref: common/link.yaml
+      allOf:
+        - $ref: common/link.yaml
+        - type: object
+          required:
+            - type
   hoursOfService:
     type: object
     description:


### PR DESCRIPTION
- Require the rel type to be the icon in the logo for contacts
- Require the type field in the logo (I was even thinking to add the following pattern: `^image/` - thoughts?)
- The type in "links" is also required, it seems