### PR TITLE
JSON Schema -> OpenAPI

### DIFF
--- a/core/openapi/schemas/contact.yaml
+++ b/core/openapi/schemas/contact.yaml
@@ -37,7 +37,8 @@ properties:
           - type
         properties:
           rel:
-            const: "icon"
+            enum:
+              - icon
   phones:
     type: array
     description: Telephone numbers at which contact can be made.


### PR DESCRIPTION
Sorry, @pvretano. I just realized that I can't just copy from JSON Schema as const is not defined in OpenAPI, instead I have to use enum...