### PR TITLE
Remove comment about empty `q` parameter.

### DIFF
--- a/core/standard/recommendations/records-api/REC_param-q.adoc
+++ b/core/standard/recommendations/records-api/REC_param-q.adoc
@@ -2,10 +2,9 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/records-api/param-q*
-^|A |The q operator SHOULD at least be applied to the following core queryables:
+The q operator SHOULD at least be applied to the following core queryables:
 
 * title
 * description
 * keywords
-^|B |If an empty q operator is passed (i.e. `+q=+`), the server SHOULD ignore this operator as if it was not specified by the client.
 |===

--- a/core/standard/requirements/crawlable-catalogue/REQ_collections-links.adoc
+++ b/core/standard/requirements/crawlable-catalogue/REQ_collections-links.adoc
@@ -7,3 +7,5 @@
 ^|B |A collections object SHALL include a link (`rel=root`) that points to its root collections object.  If this collections object is the root then it SHALL point to itself.
 ^|C |A collections object SHALL include one typed link (`rel=alternate`) for each alternative representation of itself.
 |===
+
+NOTE: The term "typed link" means a link that specifies a value for the `type` attribute

--- a/core/standard/requirements/record-core/REQ_record-links.adoc
+++ b/core/standard/requirements/record-core/REQ_record-links.adoc
@@ -4,5 +4,7 @@
 ^|*Requirement {counter:req-id}* |*/req/core/record-links*
 ^|A |Each record SHALL include a link (`rel="self"`) to itself.
 ^|B |Each record SHALL, if it is a member of a collection, include a link (`rel="collection"`) pointing to the collection of which this record in a member.
-^|C |Each record SHALL, if they exist, include links (`rel="alternate"`) to each alternative representation of the record.
+^|C |Each record SHALL, if they exist, include typed links (`rel="alternate"`) to each alternative representation of the record.
 |===
+
+NOTE: The term "typed link" means a link that specifies a value for the `type` attribute

--- a/core/standard/requirements/record-core/REQ_templated-link.adoc
+++ b/core/standard/requirements/record-core/REQ_templated-link.adoc
@@ -43,6 +43,8 @@ properties:
     description: A dictionary of the JSON Schema fragments defining the characteristics of each substitution variable in the link URI.
 ----
 
-^|B |Substitution variables in the templated link URI SHALL have the form `{_variable name_}`.
-^|C |For each substitution variable in a templated link URI, there SHALL be a correspondingly named entry in the `variables` dictionary.
+^|B |The link template SHALL be encoded as a link object with a property `templated` set to `true` and the URI template in `href`.
+^|C |Substitution variables in the templated link URI SHALL have the form `{_variable name_}`.
+^|D |For each substitution variable in a templated link URI, there SHALL be a correspondingly named entry in the `variables` dictionary.
+^|E |Templated links included in the HTTP header SHALL use the `Link-Template` HTTP header accorinding to the https://datatracker.ietf.org/doc/draft-ietf-httpapi-link-template/[draft "The Link-Template HTTP Header Field" specification] and SHALL forgo the inclusion of the `variables` dictionary.
 |===


### PR DESCRIPTION
Parameters defined in features, and consequently records, cannot be empty and so remove the part of the recommendation that discusses what to do if `q` is empty.  Apparently in OpenAPI you need to specify if a parameter can be empty using the `allowEmptyValue` (default value `false`) flag but as far as I can tell that is not used anywhere in Features.

Also bundled in a few other small changes related to templated links and rels.

Closes #234
Closes #281