### PR TITLE
Search terms are comma-separated

### DIFF
--- a/core/standard/requirements/records-api/REQ_query-param-q-definition.adoc
+++ b/core/standard/requirements/records-api/REQ_query-param-q-definition.adoc
@@ -17,7 +17,7 @@ schema:
 explode: false
 ----
 
-^|C |The list of search terms SHALL be comma-separated list and spaces have no special meaning.
+^|C |The list of search terms SHALL be a comma-separated list and spaces have no special meaning.
 ^|D |Keyword searches using the `q` parameter SHALL be case insensitive.
 ^|E |The specific set of text keys/fields/properties of a record to which the `q` operator is applied SHALL be left to the discretion of the implementation.
 |===

--- a/core/standard/requirements/records-api/REQ_query-param-q-definition.adoc
+++ b/core/standard/requirements/records-api/REQ_query-param-q-definition.adoc
@@ -17,6 +17,7 @@ schema:
 explode: false
 ----
 
-^|C |Keyword searches using the `q` parameter SHALL be case insensitive.
-^|D |The specific set of text keys/fields/properties of a record to which the `q` operator is applied SHALL be left to the discretion of the implementation.
+^|C |The list of search terms SHALL be comma-separated list and spaces have no special meaning.
+^|D |Keyword searches using the `q` parameter SHALL be case insensitive.
+^|E |The specific set of text keys/fields/properties of a record to which the `q` operator is applied SHALL be left to the discretion of the implementation.
 |===


### PR DESCRIPTION
Add text to the definition of the `q` parameter clarifying that that list of search terms is a comman-separated list and that spaces have no special meaning.

Closes #295