### PR TITLE
Update templated links to support both aware and unaware clients.

### DIFF
--- a/core/examples/json/associations-simple-and-uri-template.json
+++ b/core/examples/json/associations-simple-and-uri-template.json
@@ -5,19 +5,15 @@
       "type": "text/html",
       "title": "WOUDC - Data - Station List",
       "href": "https://woudc.org/data/stations"
-    },
+    }
+  ],
+  "linkTemplates": [
     {
       "rel": "item",
       "type": "image/png",
       "title": "World Ozone and Ultraviolet Radiation Data Centre (WOUDC) stations",
-      "href": "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=stations&width={width}&height={height}&format=image/png",
-      "templated": true,
+      "link-template": "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=stations&width={width}&height={height}&format=image/png",
       "variables": {
-        "crs": {
-          "description": "...",
-          "type": "string",
-          "enum": [ "EPSG:4326", "EPSG:3857" ]
-        },
         "bbox": {
           "description": "...",
           "type": "array",
@@ -27,6 +23,14 @@
           },
           "minItems": 4,
           "maxItems": 4
+        },
+        "crs": {
+          "description": "...",
+          "type": "string",
+          "enum": [
+            "EPSG:4326",
+            "EPSG:3857"
+          ]
         },
         "width": {
           "description": "...",

--- a/core/examples/json/crawlable_catalogue/collection.json
+++ b/core/examples/json/crawlable_catalogue/collection.json
@@ -1,32 +1,23 @@
 {
-    "id": "example-collection",
-    "title": "Dataset and Imagery Record examples",
-    "description": "This Collection links down to several examples of crawlable record collections of different types",
-    "extent":
+  "id": "example-collection",
+  "title": "Dataset and Imagery Record examples",
+  "description": "This Collection links down to several examples of crawlable record collections of different types",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [ -180, -90, 180, 90 ]
+      ]
+    }
+  },
+  "itemType": "feature",
+  "links": [
     {
-        "spatial":
-        {
-            "bbox":
-            [
-                [
-                    -180,
-                    -90,
-                    180,
-                    90
-                ]
-            ]
-        }
+      "rel": "item",
+      "href": "imagery_example/collection.json"
     },
-    "itemType": "feature",
-    "links":
-    [
-        {
-            "rel": "item",
-            "href": "imagery_example/collection.json"
-        },
-        {
-            "rel": "item",
-            "href": "dataset_example/collection.json"
-        }
-    ]
+    {
+      "rel": "item",
+      "href": "dataset_example/collection.json"
+    }
+  ]
 }

--- a/core/examples/json/crawlable_catalogue/dataset_example/nz-buildings-collection.json
+++ b/core/examples/json/crawlable_catalogue/dataset_example/nz-buildings-collection.json
@@ -1,69 +1,91 @@
 {
-    "id": "101290",
+  "id": "101290",
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          167.325430204,
+          -47.001329508
+        ],
+        [
+          179.413063484,
+          -47.001329508
+        ],
+        [
+          179.413063484,
+          -34.310623441
+        ],
+        [
+          167.325430204,
+          -34.310623441
+        ],
+        [
+          167.325430204,
+          -47.001329508
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "created": "2021-08-17T00:00:00Z",
+    "updated": "2021-08-17T00:00:00Z",
+    "type": "dataset",
     "title": "New Zealand Building Outlines",
     "description": "This dataset provides current outlines of buildings within mainland New Zealand captured from the latest aerial imagery. A building outline is a 2D representation of the roof outline of a building which has been classified from LINZ aerial imagery using a combination of automated and manual processes to extract and refine a building roof outline. Building outlines observed in aerial imagery larger than or equal to 10 square meters are captured in this dataset, and may include structures such as garages and large sheds. **Data vintage** This dataset shows the most recent set of building outlines extracted from the LINZ aerial imagery available on the LINZ Data Service. Current coverage includes nearly all regions of New Zealand, except parts of rural Auckland, remote parts of Bay of Plenty, Tasman and the Southern Alps, as well as Fiordland, Stewart Island and the Chatham Islands. This dataset will be updated and expanded as new aerial imagery becomes available. Since aerial imagery is flown only every few years in each region of the country, building outlines only reflect those buildings observed at the date of this aerial imagery capture, and may not reflect buildings constructed after this time period. Please refer to the [NZ Building Outlines Data Dictionary](https://nz-buildings.readthedocs.io/en/latest/introduction.html) for detailed metadata and information about this dataset.",
-    "extent":
-    {
-        "spatial":
-        {
-            "bbox":
-            [
-                [
-                    167.325430204,
-                    -47.001329508,
-                    179.413063484,
-                    -34.310623441
-                ]
-            ]
-        }
-    },
-    "itemType": "feature",
-    "keywords":
-    [
-        "New Zealand",
-        "buildings"
+    "keywords": [
+      "New Zealand"
     ],
     "language": "en-NZ",
-    "publisher":
-    {
-        "organizationName": "LINZ - Land Information New Zealand",
-        "contactInfo":
-        {
-            "onlineResource":
-            {
-                "href": "https://data.linz.govt.nz/"
-            },
-            "email": "customersupport@linz.govt.nz"
+    "publisher": {
+      "organizationName": "LINZ - Land Information New Zealand",
+      "contactInfo": {
+        "onlineResource": {
+          "href": "https://data.linz.govt.nz/"
         },
-        "roles": [ "producer" ]
+        "email": "customersupport@linz.govt.nz"
+      },
+      "roles": [
+        "producer"
+      ]
     },
-    "license": "CC-BY-4.0",
-    "links":
-    [
-        {
-            "href": "https://www.linz.govt.nz/data/licensing-and-using-data/attributing-linz-data",
-            "rel": "license",
-            "type": "text/html",
-            "title": "license"
-        },
-        {
-            "href": "nz-buildings-record.json",
-            "rel": "alternate",
-            "type": "application/geo+json",
-            "title": "OGC Record JSON of this data"
-        },
-        {
-            "href": "https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.gpkg",
-            "rel": "enclosure",
-            "type": "application/geopackage+sqlite3",
-            "length": 1449656320,
-            "title": "Data as a Geopackage"
-        },
-        {
-            "href": "./nz-building-outlines.xml",
-            "rel": "describedby",
-            "type": "text/xml",
-            "title": "ISO 19115/19139 Metadata"
-        }
-    ]
+    "formats": [
+      "GeoPackage",
+      "GeoJSONSeq",
+      "FlatGeobuf"
+    ],
+    "license": "CC-BY-4.0"
+  },
+  "links": [
+    {
+      "href": "https://www.linz.govt.nz/data/licensing-and-using-data/attributing-linz-data",
+      "rel": "license",
+      "type": "text/html",
+      "title": "license"
+    },
+    {
+      "href": "buildings-collection.json",
+      "rel": "alternate",
+      "type": "application/json",
+      "title": "OGC Collection JSON of this data",
+      "created": "2013-01-21T00:00:00Z",
+      "updated": "2020-04-23T00:00:00Z"
+    },
+    {
+      "href": "https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.gpkg",
+      "rel": "enclosure",
+      "type": "application/geopackage+sqlite3",
+      "length": 1449656320,
+      "title": "Data as a Geopackage",
+      "created": "2013-01-21T00:00:00Z",
+      "updated": "2020-04-23T00:00:00Z"
+    },
+    {
+      "href": "./nz-building-outlines.xml",
+      "rel": "describedby",
+      "type": "text/xml",
+      "title": "ISO 19115/19139 Metadata"
+    }
+  ]
 }

--- a/core/examples/json/crawlable_catalogue/dataset_example/nz-buildings-record.json
+++ b/core/examples/json/crawlable_catalogue/dataset_example/nz-buildings-record.json
@@ -1,98 +1,91 @@
 {
-    "id": "101290",
-    "type": "Feature",
-    "geometry":
-    {
-        "type": "Polygon",
-        "coordinates":
+  "id": "101290",
+  "type": "Feature",
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
         [
-            [
-                [
-                    167.325430204,
-                    -47.001329508
-                ],
-                [
-                    179.413063484,
-                    -47.001329508
-                ],
-                [
-                    179.413063484,
-                    -34.310623441
-                ],
-                [
-                    167.325430204,
-                    -34.310623441
-                ],
-                [
-                    167.325430204,
-                    -47.001329508
-                ]
-            ]
+          167.325430204,
+          -47.001329508
+        ],
+        [
+          179.413063484,
+          -47.001329508
+        ],
+        [
+          179.413063484,
+          -34.310623441
+        ],
+        [
+          167.325430204,
+          -34.310623441
+        ],
+        [
+          167.325430204,
+          -47.001329508
         ]
-    },
-    "properties":
-    {
-        "created": "2021-08-17T00:00:00Z",
-        "updated": "2021-08-17T00:00:00Z",
-        "type": "dataset",
-        "title": "New Zealand Building Outlines",
-        "description": "This dataset provides current outlines of buildings within mainland New Zealand captured from the latest aerial imagery. A building outline is a 2D representation of the roof outline of a building which has been classified from LINZ aerial imagery using a combination of automated and manual processes to extract and refine a building roof outline. Building outlines observed in aerial imagery larger than or equal to 10 square meters are captured in this dataset, and may include structures such as garages and large sheds. **Data vintage** This dataset shows the most recent set of building outlines extracted from the LINZ aerial imagery available on the LINZ Data Service. Current coverage includes nearly all regions of New Zealand, except parts of rural Auckland, remote parts of Bay of Plenty, Tasman and the Southern Alps, as well as Fiordland, Stewart Island and the Chatham Islands. This dataset will be updated and expanded as new aerial imagery becomes available. Since aerial imagery is flown only every few years in each region of the country, building outlines only reflect those buildings observed at the date of this aerial imagery capture, and may not reflect buildings constructed after this time period. Please refer to the [NZ Building Outlines Data Dictionary](https://nz-buildings.readthedocs.io/en/latest/introduction.html) for detailed metadata and information about this dataset.",
-        "keywords":
-        [
-            "New Zealand"
-        ],
-        "language": "en-NZ",
-        "publisher":
-        {
-            "organizationName": "LINZ - Land Information New Zealand",
-            "contactInfo":
-            {
-                "onlineResource":
-                {
-                    "href": "https://data.linz.govt.nz/"
-                },
-                "email": "customersupport@linz.govt.nz"
-            },
-            "roles": [ "producer" ]
-        },
-        "formats":
-        [
-            "GeoPackage",
-            "GeoJSONSeq",
-            "FlatGeobuf"
-        ],
-        "license": "CC-BY-4.0"
-    },
-    "links":
-    [
-        {
-            "href": "https://www.linz.govt.nz/data/licensing-and-using-data/attributing-linz-data",
-            "rel": "license",
-            "type": "text/html",
-            "title": "license"
-        },
-        {
-            "href": "buildings-collection.json",
-            "rel": "alternate",
-            "type": "application/json",
-            "title": "OGC Collection JSON of this data",
-            "created": "2013-01-21T00:00:00Z",
-            "updated": "2020-04-23T00:00:00Z"
-        },
-        {
-            "href": "https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.gpkg",
-            "rel": "enclosure",
-            "type": "application/geopackage+sqlite3",
-            "length": 1449656320,
-            "title": "Data as a Geopackage",
-            "created": "2013-01-21T00:00:00Z",
-            "updated": "2020-04-23T00:00:00Z"
-        },
-        {
-            "href": "./nz-building-outlines.xml",
-            "rel": "describedby",
-            "type": "text/xml",
-            "title": "ISO 19115/19139 Metadata"
-        }
+      ]
     ]
+  },
+  "properties": {
+    "created": "2021-08-17T00:00:00Z",
+    "updated": "2021-08-17T00:00:00Z",
+    "type": "dataset",
+    "title": "New Zealand Building Outlines",
+    "description": "This dataset provides current outlines of buildings within mainland New Zealand captured from the latest aerial imagery. A building outline is a 2D representation of the roof outline of a building which has been classified from LINZ aerial imagery using a combination of automated and manual processes to extract and refine a building roof outline. Building outlines observed in aerial imagery larger than or equal to 10 square meters are captured in this dataset, and may include structures such as garages and large sheds. **Data vintage** This dataset shows the most recent set of building outlines extracted from the LINZ aerial imagery available on the LINZ Data Service. Current coverage includes nearly all regions of New Zealand, except parts of rural Auckland, remote parts of Bay of Plenty, Tasman and the Southern Alps, as well as Fiordland, Stewart Island and the Chatham Islands. This dataset will be updated and expanded as new aerial imagery becomes available. Since aerial imagery is flown only every few years in each region of the country, building outlines only reflect those buildings observed at the date of this aerial imagery capture, and may not reflect buildings constructed after this time period. Please refer to the [NZ Building Outlines Data Dictionary](https://nz-buildings.readthedocs.io/en/latest/introduction.html) for detailed metadata and information about this dataset.",
+    "keywords": [
+      "New Zealand"
+    ],
+    "language": "en-NZ",
+    "publisher": {
+      "organizationName": "LINZ - Land Information New Zealand",
+      "contactInfo": {
+        "onlineResource": {
+          "href": "https://data.linz.govt.nz/"
+        },
+        "email": "customersupport@linz.govt.nz"
+      },
+      "roles": [
+        "producer"
+      ]
+    },
+    "formats": [
+      "GeoPackage",
+      "GeoJSONSeq",
+      "FlatGeobuf"
+    ],
+    "license": "CC-BY-4.0"
+  },
+  "links": [
+    {
+      "href": "https://www.linz.govt.nz/data/licensing-and-using-data/attributing-linz-data",
+      "rel": "license",
+      "type": "text/html",
+      "title": "license"
+    },
+    {
+      "href": "buildings-collection.json",
+      "rel": "alternate",
+      "type": "application/json",
+      "title": "OGC Collection JSON of this data",
+      "created": "2013-01-21T00:00:00Z",
+      "updated": "2020-04-23T00:00:00Z"
+    },
+    {
+      "href": "https://storage.googleapis.com/open-geodata/linz-examples/nz-building-outlines.gpkg",
+      "rel": "enclosure",
+      "type": "application/geopackage+sqlite3",
+      "length": 1449656320,
+      "title": "Data as a Geopackage",
+      "created": "2013-01-21T00:00:00Z",
+      "updated": "2020-04-23T00:00:00Z"
+    },
+    {
+      "href": "./nz-building-outlines.xml",
+      "rel": "describedby",
+      "type": "text/xml",
+      "title": "ISO 19115/19139 Metadata"
+    }
+  ]
 }

--- a/core/examples/json/record.json
+++ b/core/examples/json/record.json
@@ -128,28 +128,13 @@
     ],
     "license": "other"
   },
-  "links": [
-    {
-      "rel": "alternate",
-      "type": "text/html",
-      "title": "This document as HTML",
-      "href": "https://woudc.org/data/dataset_info.php?id=totalozone"
-    },
+  "linkTemplates": [
     {
       "rel": "item",
       "type": "image/png",
-      "title": "OGC Web Map Service (WMS)",
-      "href": "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=totalozone&width={width}&height={height}&format=image/png",
-      "templated": true,
+      "title": "World Ozone and Ultraviolet Radiation Data Centre (WOUDC) stations",
+      "link-template": "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=stations&width={width}&height={height}&format=image/png",
       "variables": {
-        "crs": {
-          "description": "...",
-          "type": "string",
-          "enum": [
-            "EPSG:4326",
-            "EPSG:3857"
-          ]
-        },
         "bbox": {
           "description": "...",
           "type": "array",
@@ -159,6 +144,14 @@
           },
           "minItems": 4,
           "maxItems": 4
+        },
+        "crs": {
+          "description": "...",
+          "type": "string",
+          "enum": [
+            "EPSG:4326",
+            "EPSG:3857"
+          ]
         },
         "width": {
           "description": "...",
@@ -175,6 +168,14 @@
           "maximum": 5000
         }
       }
+    }
+  ],
+  "links": [
+    {
+      "rel": "alternate",
+      "type": "text/html",
+      "title": "This document as HTML",
+      "href": "https://woudc.org/data/dataset_info.php?id=totalozone"
     },
     {
       "rel": "enclosure",

--- a/core/examples/json/templated-link-inline.json
+++ b/core/examples/json/templated-link-inline.json
@@ -2,17 +2,8 @@
   "rel": "item",
   "type": "image/png",
   "title": "World Ozone and Ultraviolet Radiation Data Centre (WOUDC) stations",
-  "href": "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=stations&width={width}&height={height}&format=image/png",
-  "templated": true,
+  "link-template": "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=stations&width={width}&height={height}&format=image/png",
   "variables": {
-    "crs": {
-      "description": "...",
-      "type": "string",
-      "enum": [
-        "EPSG:4326",
-        "EPSG:3857"
-      ]
-    },
     "bbox": {
       "description": "...",
       "type": "array",
@@ -22,6 +13,14 @@
       },
       "minItems": 4,
       "maxItems": 4
+    },
+    "crs": {
+      "description": "...",
+      "type": "string",
+      "enum": [
+        "EPSG:4326",
+        "EPSG:3857"
+      ]
     },
     "width": {
       "description": "...",

--- a/core/examples/json/templated-link-ref.json
+++ b/core/examples/json/templated-link-ref.json
@@ -1,0 +1,7 @@
+{
+  "rel": "item",
+  "type": "image/png",
+  "title": "World Ozone and Ultraviolet Radiation Data Centre (WOUDC) stations",
+  "link-template": "https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=stations&width={width}&height={height}&format=image/png",
+  "varBase": "https://www.someserver.com/variables/"
+}

--- a/core/examples/json/variables.json
+++ b/core/examples/json/variables.json
@@ -1,0 +1,20 @@
+{
+  "bbox": {
+    "description": "...",
+    "type": "array",
+    "items": {
+      "type": "number",
+      "format": "double"
+    },
+    "minItems": 4,
+    "maxItems": 4
+  },
+  "crs": {
+    "description": "...",
+    "type": "string",
+    "enum": [
+      "EPSG:4326",
+      "EPSG:3857"
+    ]
+  }
+}

--- a/core/openapi/ogcapi-records-1.yaml
+++ b/core/openapi/ogcapi-records-1.yaml
@@ -202,6 +202,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/link"
+        linkTemplates:
+          type: array
+          items:
+            $ref: "#/components/schemas/linkTemplate"
         extent:
           $ref: "#/components/schemas/extent"
         itemType:
@@ -228,6 +232,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/link"
+        linkTemplates:
+          type: array
+          items:
+            $ref: "#/components/schemas/linkTemplate"
         collections:
           type: array
           items:
@@ -435,6 +443,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/link"
+        linkTemplates:
+          type: array
+          items:
+            $ref: "#/components/schemas/linkTemplate"
     linestringGeoJSON:
       type: object
       required:
@@ -470,16 +482,25 @@ components:
           type: string
         length:
           type: integer
-        templated:
-          type: boolean
-        variables:
-          type: object
         created:
           type: string
           format: date-time
         updated:
           type: string
           format: date-time
+    linkTemplate:
+      allOf:
+        - $ref: "#/components/schemas/link"
+        - oneOf:
+          - type: object
+            properties:
+              variables:
+                type: object
+          - type: object
+            properties:
+              varBase:
+                type: string
+                format: url
     multilinestringGeoJSON:
       type: object
       required:

--- a/core/openapi/schemas/common/collectionInfo.yaml
+++ b/core/openapi/schemas/common/collectionInfo.yaml
@@ -1,42 +1,40 @@
 ---
-type: object
-required:
-  - id
-  - links
-  - itemType
-properties:
-  id:
-    type: string
-  title:
-    type: string
-  description:
-    type: string
-  links:
-    type: array
-    items:
-      $ref: link.yaml
-  extent:
-    $ref: extent.yaml
-  itemType:
-    description: |-
-      indicator about the type of the items in the collection
-    type: string
-    enum:
-      - collection
-      - record
-  crs:
-    description: |-
-      the list of coordinate reference systems supported by the API; the
-      first item is the default coordinate reference system
-    type: array
-    items:
-      type: string
-    default:
-      - http://www.opengis.net/def/crs/OGC/1.3/CRS84
-  defaultSortOrder:
-    description: |-
-      an array of sortables, optionally prepended with a plus or minus sign,
-      indicating the default sort order
-    type: array
-    items:
-      type: string
+allOf:
+  - $ref: links.yaml
+  - type: object
+    required:
+      - id
+      - links
+      - itemType
+    properties:
+      id:
+        type: string
+      title:
+        type: string
+      description:
+        type: string
+      extent:
+        $ref: extent.yaml
+      itemType:
+        description: |-
+          indicator about the type of the items in the collection
+        type: string
+        enum:
+          - collection
+          - record
+      crs:
+        description: |-
+          the list of coordinate reference systems supported by the API; the
+          first item is the default coordinate reference system
+        type: array
+        items:
+          type: string
+        default:
+          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+      defaultSortOrder:
+        description: |-
+          an array of sortables, optionally prepended with a plus or minus sign,
+          indicating the default sort order
+        type: array
+        items:
+          type: string

--- a/core/openapi/schemas/common/collections.yaml
+++ b/core/openapi/schemas/common/collections.yaml
@@ -1,14 +1,12 @@
 ---
-type: object
-required:
-  - links
-  - collections
-properties:
-  links:
-    type: array
-    items:
-      $ref: link.yaml
-  collections:
-    type: array
-    items:
-      $ref: collectionInfo.yaml
+allOf:
+  - $ref: links.yaml
+  - type: object
+    required:
+      - links
+      - collections
+    properties:
+      collections:
+        type: array
+        items:
+          $ref: collectionInfo.yaml

--- a/core/openapi/schemas/common/landingPage.yaml
+++ b/core/openapi/schemas/common/landingPage.yaml
@@ -1,16 +1,13 @@
 ---
-type: object
-required:
-  - links
-properties:
-  title:
-    description: The title of the API
-    type: string
-  description:
-    description: A textual description of the API
-    type: string
-  links:
-    description: Links to the resources exposed through this API.
-    type: array
-    items:
-      $ref: link.yaml
+allOf:
+  - $ref: links.yaml
+  - type: object
+    required:
+      - links
+    properties:
+      title:
+        description: The title of the API
+        type: string
+      description:
+        description: A textual description of the API
+        type: string

--- a/core/openapi/schemas/common/link.yaml
+++ b/core/openapi/schemas/common/link.yaml
@@ -1,37 +1,13 @@
 ---
-type: object
-required:
-  - href
-properties:
-  href:
-    type: string
-    format: url
-  rel:
-    type: string
-  type:
-    type: string
-  hreflang:
-    type: string
-  title:
-    type: string
-  templated:
-    type: boolean
-  variables:
-    description: |-
-      This object contains one key per substitution variable in a templated
-      href.  Each key defines the schema of one substitution variable using
-      a JSON Schema fragment and can thus include things like the data type
-      of the variable, enumerations, minimum values, maximum values, etc.
-      In combination with a templated href, the variables section should
-      provide enough information to bind to the target resource (e.g. a WMS).
-    type: object
-  created:
-    type: string
-    description:
-      Date of creation of the resource pointed to by the link.
-    format: date-time
-  updated:
-    type: string
-    description:
-      Most recent date on which the resource pointed to by the link was changed.
-    format: date-time
+allOf:
+  - $ref: linkBase.yaml
+  - type: object
+    required: href
+    properties: 
+      href:
+        type: string
+        description:
+          Supplies a resolvable URI to a remote resource
+          (or resource fragment).
+        format: url
+        example: http://data.example.com/buildings/123

--- a/core/openapi/schemas/common/linkBase.yaml
+++ b/core/openapi/schemas/common/linkBase.yaml
@@ -1,0 +1,40 @@
+---
+type: object
+properties:
+  rel:
+    type: string
+    description: The type or semantics of the relation.
+    example: alternate
+  type:
+    type: string
+    description:
+      A hint indicating what the media type of the
+      result of dereferencing the link should be.
+    example: application/geo+json
+  hreflang:
+    type: string
+    description:
+      A hint indicating what the language of the
+      result of dereferencing the link should be.
+    example: en
+  title:
+    type: string
+    description:
+      Used to label the destination of a link
+      such that it can be used as a human-readable
+      identifier.
+    example: "Trierer Strasse 70, 53115 Bonn"
+  length:
+    type: integer
+  created:
+    type: string
+    description:
+      Date of creation of the resource pointed to
+      by the link.
+    format: date-time
+  updated:
+    type: string
+    description:
+      Most recent date on which the resource pointed
+      to by the link was changed.
+    format: date-time

--- a/core/openapi/schemas/common/linkTemplate.yaml
+++ b/core/openapi/schemas/common/linkTemplate.yaml
@@ -1,0 +1,28 @@
+---
+allOf:
+  - $ref: linkBase.yaml
+  - type: object
+    required: link-template
+    properties: 
+      link-template:
+        type: string
+        description:
+          Supplies a resolvable URI to a remote resource
+          (or resource fragment).
+        example: http://data.example.com/buildings/(building-id}
+      variables:
+        type: object
+        description:
+          This object contains one key per substitution
+          variable in the templated URL.  Each key defines
+          the schema of one substitution variable using a
+          JSON Schema fragment and can thus include things
+          like the data type of the variable, enumerations,
+          minimum values, maximum values, etc.
+      varBase:
+        type: string
+        description:
+          The base URI to which the variable name can be
+          appended to retrieve the definition of the
+          variable as a JSON Schema fragment.
+        format: url

--- a/core/openapi/schemas/common/links.yaml
+++ b/core/openapi/schemas/common/links.yaml
@@ -1,0 +1,10 @@
+type: object
+properties:
+  links:
+    type: array
+    items:
+      $ref: link.yaml
+  linkTemplates:
+    type: array
+    items:
+      $ref: linkTemplate.yaml

--- a/core/openapi/schemas/featureCollectionGeoJSON.yaml
+++ b/core/openapi/schemas/featureCollectionGeoJSON.yaml
@@ -1,27 +1,25 @@
 ---
-type: object
-required:
-  - type
-  - features
-properties:
-  type:
-    type: string
-    enum:
-      - FeatureCollection
-  features:
-    type: array
-    items:
-      $ref: record.yaml
-  links:
-    type: array
-    items:
-      $ref: link.yaml
-  timeStamp:
-    type: string
-    format: date-time
-  numberMatched:
-    type: integer
-    minimum: 0
-  numberReturned:
-    type: integer
-    minimum: 0
+allOf:
+  - $ref: common/links.yaml
+  - type: object
+    required:
+      - type
+      - features
+    properties:
+      type:
+        type: string
+        enum:
+          - FeatureCollection
+      features:
+        type: array
+        items:
+          $ref: record.yaml
+      timeStamp:
+        type: string
+        format: date-time
+      numberMatched:
+        type: integer
+        minimum: 0
+      numberReturned:
+        type: integer
+        minimum: 0

--- a/core/openapi/schemas/recordGeoJSON.yaml
+++ b/core/openapi/schemas/recordGeoJSON.yaml
@@ -1,159 +1,133 @@
 ---
-type: object
-required:
-  - id
-  - type
-  - time
-  - geometry
-  - properties
-  - links
-properties:
-  id:
-    type: string
-    description:
-      A unique identifier of the catalogue record.
-    format: uri
-  conformsTo:
-    $ref: common/confClasses.yaml#/properties/conformsTo
-  type:
-    type: string
-    enum:
-      - Feature
-  time:
-    $ref: time.yaml
-  geometry:
-    oneOf:
-      - enum:
-        - null
-      - $ref: geometryGeoJSON.yaml
-  properties:
-    type: object
+allOf:
+  - $ref: common/links.yaml
+  - type: object
     required:
+      - id
       - type
-      - title
+      - time
+      - geometry
+      - properties
+      - links
     properties:
-      created:
+      id:
         type: string
         description:
-          Date of creation of this record.
-        format: date-time
-      updated:
-        type: string
-        description:
-          The most recent date on which the record was
-          changed.
-        format: date-time
+          A unique identifier of the catalogue record.
+        format: uri
+      conformsTo:
+        $ref: common/confClasses.yaml#/properties/conformsTo
       type:
         type: string
-        description:
-          The nature or genre of the resource. The value
-          should be a code, convenient for filtering
-          records. Where available, a link to the
-          canonical URI of the record type resource will
-          be added to the 'links' property.
-        maxLength: 64
-      title:
-        type: string
-        description:
-          A human-readable name given to the resource.
-      description:
-        type: string
-        description:
-          A free-text account of the resource.
-      keywords:
-        type: array
-        description:
-          The topic or topics of the resource. Typically
-          represented using free-form keywords, tags,
-          key phrases, or classification codes.
-        items:
-          type: string
-      language:
-        description:
-          The language used for textual values in this
-          record representation.
-        $ref: language.yaml
-      languages:
-        type: array
-        description:
-          This list of languages in which this record
-          is available.
-        items:
-          $ref: language.yaml
-      resourceLanguages:
-        type: array
-        description:
-          The list of languages in which the resource
-          described by this record is available.
-        items:
-          $ref: language.yaml
-      externalIds:
-        type: array
-        description:
-          An identifier for the resource assigned by
-          an external (to the catalogue) entity.
-        items:
-          type: object
-          properties:
-            scheme:
+        enum:
+          - Feature
+      time:
+        $ref: time.yaml
+      geometry:
+        oneOf:
+          - enum:
+            - null
+          - $ref: geometryGeoJSON.yaml
+      properties:
+        type: object
+        required:
+          - type
+          - title
+        properties:
+          created:
+            type: string
+            description:
+              Date of creation of this record.
+            format: date-time
+          updated:
+            type: string
+            description:
+              The most recent date on which the record was changed.
+            format: date-time
+          type:
+            type: string
+            description:
+              The nature or genre of the resource. The value should be a code,
+              convenient for filtering records. Where available, a link to
+              the canonical URI of the record type resource will be added to
+              the 'links' property.
+            maxLength: 64
+          title:
+            type: string
+            description:
+              A human-readable name given to the resource.
+          description:
+            type: string
+            description:
+              A free-text account of the resource.
+          keywords:
+            type: array
+            description:
+              The topic or topics of the resource. Typically represented using
+              free-form keywords, tags, key phrases, or classification codes.
+            items:
               type: string
-              description:
-                A reference to an authority or
-                identifier for a knowledge
-                organization system from which
-                the external identifier was
-                obtained.  It is recommended
-                that the identifier be a
-                resolvable URI.
-            value:
+          language:
+            description:
+              The language used for textual values in this record representation.
+            $ref: language.yaml
+          languages:
+            type: array
+            description:
+              This list of languages in which this record is available.
+            items:
+              $ref: language.yaml
+          resourceLanguages:
+            type: array
+            description:
+              The list of languages in which the resource described by this
+              record is available.
+            items:
+              $ref: language.yaml
+          externalIds:
+            type: array
+            description:
+              An identifier for the resource assigned by an external (to the
+              catalogue) entity.
+            items:
+              type: object
+              properties:
+                scheme:
+                  type: string
+                  description:
+                    A reference to an authority or identifier for a knowledge
+                    organization system from which the external identifier was
+                    obtained.  It is recommended that the identifier be a
+                    resolvable URI.
+                value:
+                  type: string
+                  description: The value of the identifier.
+              required:
+                - value
+          themes:
+            type: array
+            description:
+              A knowledge organization system used to classify the resource.
+            minItems: 1
+            items:
+              $ref: theme.yaml
+          formats:
+            type: array
+            description:
+              A list of available distributions of the resource.
+            items:
               type: string
-              description:
-                The value of the identifier.
-          required:
-            - value
-      themes:
-        type: array
-        description:
-          A knowledge organization system used
-          to classify the resource.
-        minItems: 1
-        items:
-          $ref: theme.yaml
-      formats:
-        type: array
-        description:
-          A list of available distributions of
-          the resource.
-        items:
-          type: string
-      contacts:
-        type: array
-        description:
-          A list of contacts qualified by their
-          role(s) in association to the record
-          or the resource described by the record.
-        items:
-          $ref: contact.yaml
-      license:
-        $ref: license.yaml
-      rights:
-        type: string
-        description:
-          A statement that concerns all rights
-          not addressed by the license such as
-          a copyright statement.
-  links:
-    type: array
-    description:
-      A list of links for accessing the resource
-      (e.g. download link, access link) in one of
-      the supported distribution formats and/or
-      links to other resources associated with this
-      resource. Also, a list of links for navigating
-      the API (e.g. prev, next, etc.).  Since the
-      specification requires that at least the self
-      link be present then the min items for this
-      list should be one.
-    items:
-      minItems: 1
-      $ref: common/link.yaml
+          contacts:
+            type: array
+            description:
+              A list of contacts qualified by their role(s) in association
+              to the record or the resource described by the record.
+            items:
+              $ref: contact.yaml
+          license:
+            $ref: license.yaml
+          rights:
+            type: string
+            description:
+              A statement that concerns all rights not addressed by the license
+              such as a copyright statement.

--- a/core/standard/clause_3_references.adoc
+++ b/core/standard/clause_3_references.adoc
@@ -27,6 +27,7 @@ The following normative documents contain provisions that, through reference in 
 * W3C: W3C Working Draft, The app: URI scheme, 2013
 * ISO/IEC: ISO/IEC 19757-3:2006 Information technology – Document Schema Definition Languages (DSDL) – Part 3: Rule-based validation – Schematron, 2006
 * ISO 8601: ISO 8601:2004: Data elements and interchange formats — Information interchange — Representation of dates and times, https://www.iso.org/standard/40874.html, 2004
+* [[link-template]] IETF: https://ietf-wg-httpapi.github.io/link-template/draft-ietf-httpapi-link-template.html[draft-ietf-httpapi-link-template-latest]
 * IETF: RFC 2183, 1997
 * IETF: RFC 2387, 1998
 * IETF: RFC 2392, 1998

--- a/core/standard/clause_7_building_blocks.adoc
+++ b/core/standard/clause_7_building_blocks.adoc
@@ -247,7 +247,7 @@ include::requirements/record-core/REQ_record-license.adoc[]
 [[sc_associations_and_links]]
 ===== Associations and Links
 
-A record must contain a `links` section.  This `links` section many contain navigation links and/or association links.
+A record must contain a `links` section and may contain a <<sc_templated_links_with_variables,`linkTemplates`>> section.  These sections contain navigation links and/or association links.
 
 Navigation links are meant to encode relationships between catalog entities (i.e. <<clause-core-record-collection,collections>> and <<clause-record-core,records>>).  Navigation links in the `links` section can include links to the collection (`rel="collection`) of which a record is a member, alternative representations (`rel="alternate"`) of the record, and -- in the context of an API -- navigation links to previous (`rel="prev"`) or next (`rel="next"`) records in a chain of records.  Links in the `links` section may also be used to organize records in a hierarchy (`rel="root"`, `rel="parent"`, `rel="child`).
 
@@ -273,56 +273,91 @@ In some instances additional context may be desirable or required in order to ac
 
 include::recommendations/record-core/REC_record-associations_templated.adoc[]
 
-NOTE: This specification does not define any specific link relations that should be used for links in the `links` section.  Such relationships are typically domain specific and so it is left to communities of interest to standardize the links that relations should use.
+NOTE: This specification does not define any specific link relations that should be used for links in the `links` or <<sc_templated_links_with_variables,`linkTemplates`>> sections.  Such relationships are typically domain specific and so it is left to communities of interest to standardize the relations that links should use.
 
-The following provides an example of using association links for related resources of a record, as both traditional link relations as well as API resources via URI templates.
+The following provides an example of using association links for related resources of a record, as both traditional links as well as link templates.
 
 [#associations-simple-and-uri-template-example,reftext=`Associations simple and URI Template Example`]
-.Associations simple and URI Template Example
+.Associations simple and Link Template Example
 [source,json]
 ----
 include::../examples/json/associations-simple-and-uri-template.json[]
 ----
 
-[[example_11]]
-.Links in a record payload
-=====
-The links in a record could be (in this example represented as link headers):
-
+[#links-in-https-headers,reftext=`Example of links in HTTP headers`]
+￼.Example of links and link templates in HTTP headers
 [source]
 ----
-Link: <http://data.example.org/collections/my_catalog/items/record_123.json>; rel="self"; type="application/geo+json"
-Link: <http://data.example.org/collections/my_catalog/items/record_123.html>; rel="alternate"; type="text/html"
-Link: <http://data.example.org/collections/my_catalog.json>; rel="collection"; type="application/json"
-Link: <http://data.example.org/collections/my_catalog.html>; rel="collection"; type="text/html"
+Link: <https://woudc.org/data/stations>; rel="search"; type="text/html"
+Link-Template: <https://geo.woudc.org/ows?service=WMS&version=1.3.0&request=GetMap&crs={crs}&bbox={bbox}&layers=stations&width={width}&height={height}&format=image/png>; rel="item"; type="image/png"; varBase="https://geo.woudc.org/variables/"
 ----
-=====
 
 [[sc_templated_links_with_variables]]
 ===== Templated links with variables
 
 OGC API - Records uses links to express associations between resources including links that bind to the resource(s) being described by a record.  In some situations, a static link does not adequately express all the information necessary to retrieve the referenced resource OR does not allow for the resource to be retrieved in an efficient manner.
 
-Consider the case where a record describing a coverage resource is discovered by searching the catalog using a spatial constraint (e.g. a bbox).  Further consider that the found record contains a link to retrieve the coverage.  Using a static link for the binding link would only allow retrieval of the entire coverage.  Using a templated link, however, would allow the context of the catalog query (i.e. the bbox) to be passed to down to the binding link.  The templated link with all substitution values resolved would thus retrieve the subset of the coverage that corresponds to the spatial contraint used to discover the record in the first place which presumably represents the area of interest.
+Consider the case where a record describing a coverage resource is discovered by searching the catalogue using a spatial constraint (e.g. a bbox).  Further consider that the found record contains a link to retrieve the coverage.  Using a static link would only allow for retrieval of the entire coverage or a subset unrelated to the user's original catalogue query.  Using a templated link, however, would allow the context of the catalogue query (i.e. the bbox) to be passed to the retrieval link as a substitution variable.  The templated link with all substitution variables resolved would thus retrieve the subset of the coverage that corresponds to the spatial contraint used to discover the record in the first place which presumably represents the area of interest.
 
-Templated links may also be used to bind to resources that may require additional information in order to access the resources.  For example, simply knowing the URL of a legacy OGC service such as WMS or WFS is not sufficient to access resources offered by those services.  Additional information in the form of request parameters and values are required in order to have a complete link to a resources.  A templated link with variables can provide this additional context.
+Templated links may also be used to bind to resources that may require additional information in order to access the resources.  For example, simply knowing the URL of a legacy OGC service such as https://portal.ogc.org/files/?artifact_id=14416[WMS] or https://docs.ogc.org/is/09-025r2/09-025r2.html[WFS] is not sufficient to access resources offered by those services.  Additional information in the form of request parameters and values are required in order to have a complete link to a resource.  A templated link with variables can provide this additional context.
 
-This specification extends the https://github.com/opengeospatial/ogcapi-common/blob/master/core/openapi/schemas/link.json[schema for a link] to include substitution variables who values are filled in at runtime prior to resolving the link.
+This specification defines a new schema, https://github.com/opengeospatial/ogcapi-common/blob/master/core/openapi/schemas/linkTemplate.yaml[linkTemplate.yaml],  based on the https://github.com/opengeospatial/ogcapi-common/blob/master/core/openapi/schemas/link.json[schema for a link] that includes substitution variables who's values are filled in at runtime prior to resolving the link.  
 
-The https://schemas.opengis.net/ogcapi/common/part1/1.0/openapi/schemas/link.yaml[link schema] is extended with the addition of two properties named `templated` and `variables`.  The `templated` property is a boolean that is used to indicate the the URL of the link (i.e. `href`) is a template and contains substitution variables.  The `variables` property uses https://json-schema.org/draft/2020-12/json-schema-validation.html[JSON Schema fragments] to define the characteristics of each substitution variable referenced in the templated link URL.
+Information about the substitution variables can be obtained in one of two ways.  The `variable` property may be used to encode the definitions of substitution variables in-line in the link.  Alternatively, the `varBase` property can be used to specify a base URI to which a variable name may be appended in order to retrieve the definition of the specified substitution variable.
 
 include::requirements/record-core/REQ_templated-link.adoc[]
 
-[#templated-link-with-variables,reftext=`Associations simple and URI Template Example`]
-.Templated link with variables example
+include::recommendations/record-core/REC_templated-link.adoc[]
+￼
+::requirements/record-core/REQ_templated-link-header.adoc[]
+￼
+following example illustrates a link template to a legacy OGC Web service.  The example includes both an in-line and referenced dictionaries of substitution variables.
+￼
+[#templated-link-with-variables-inline,reftext=`Templated link example 1`]
+.Templated link with in-line dictionary of substitution variables
 [source,json]
 ----
-include::../examples/json/templated-link.json[]
+include::../examples/json/templated-link-inline.json[]
+----
+￼
+[#templated-link-with-variables-ref,reftext=`Templated link example 2`]
+.Templated link with `varBase` URI for retrieving substitution variable definitions
+[source,json]
+----
+include::../examples/json/templated-link-ref.json[]
+----
+￼
+[#variable-def,reftext=`Variable definition example`]
+.Using `varBase` to retrieve the definition of the variable bbox
+----
+   CLIENT                                                     SERVER
+     |                                                           |
+     |   GET variables/bbox HTTP/1.1                             |
+     |   Host: www.someserver.com                                |
+     |   Accept: application/json                                |
+     |---------------------------------------------------------->|
+     |                                                           |
+     |   HTTP/1.1 200 OK                                         |
+     |   Content-Type: application/json                          |
+     |                                                           |
+     |   {                                                       |
+     |     "bbox": {                                             |
+     |       "description": "...",                               |
+     |       "type": "array",                                    |
+     |       "items": {                                          |
+     |         "type": "number",                                 |
+     |         "format": "double"                                |
+     |       },                                                  |
+     |       "minItems": 4,                                      |
+     |       "maxItems": 4                                       |
+     |     }                                                     |
+     |   }                                                       |
+     |<----------------------------------------------------------|
 ----
 
 ===== Resource timestamps
 
-A <<core-properties,record>> contains information, encoded in the links section, for accessing one or more resources described by the record.  Since a resource may have multiple representations there may be multiple links pointing to each represention of a resource.  Furthermore, representations of a resource may be created and updated at different times.  In order to capture this life cycle information of resource representations, the https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/common/link.yaml[link schema] is extended with the addition of two properties named `created` and `updated`.  The values of these properties are used to indicate the creation and last updated dates of the resource representation pointed to by the link.
+A <<core-queryables,record>> contains information, encoded in the links and link templates sections, for accessing one or more resources described by the record.  Since a resource may have multiple representations there may be multiple links pointing to each represention of a resource.  Furthermore, representations of a resource may be created and updated at different times.  In order to capture this life cycle information of resource representations, the https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/common/link.yaml[link schema] is extended with the addition of two properties named `created` and `updated`.  The values of these properties are used to indicate the creation and last updated dates of the resource representation pointed to by the link.
 
 [[sc_record_language_handling]]
 ===== Language handling
@@ -339,7 +374,7 @@ A catalog record can include language information about:
 
 include::recommendations/record-core/REC_record-lang.adoc[]
 
-The https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/common/link.yaml[link object] based on https://docs.ogc.org/is/17-069r4/17-069r4.html#rfc8228[RFC 8288 (Web Linking)] includes a `hreflang` attribute that can be used to state the language of a referenced resource.  This can be used to include links to the same record in different languges.  
+The https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/common/link.yaml[link object] and the https://github.com/opengeospatial/ogcapi-records/blob/master/core/openapi/schemas/common/linkTemplated.yaml[templated link object] are based on https://docs.ogc.org/is/17-069r4/17-069r4.html#rfc8228[RFC 8288 (Web Linking)] includes a `hreflang` attribute that can be used to state the language of a referenced resource.  This can be used to include links to the same record in different languges. 
 
 [[minting-language-specific-uris]]
 A server that wants to use language-specific links will have to support a mechanism to mint language-specific URIs in order to express links to the same record in other languages or to express links to the resource described by record in multiple languages.  This document does not mandate any particular approach how such a capability is supported by a server. 
@@ -793,17 +828,17 @@ Links can be added to a catalog record in various ways.  This clause
 describes the various linking patterns and describes how to use CQL to
 filter based on links.
 
-===== Linking in records
+===== Linking patterns in records
 
 Links can be added to the following sections in a catalog record:
 
-. the <<query-response,links>> section.
+. the <<query-response,links>> section,
+. the <<query-response,linkTemplates>> section,
 . the <<query-response,properties>> section.
 
-The schema for links added to the <<query-response,links>> section is based on https://tools.ietf.org/html/rfc8288[RFC 8288] and is described in https://docs.ogc.org/DRAFTS/19-072.html#link-relation-conventions[OGC API - Common - Part 1: Core] and http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml[OGC API - Features - Part 1: Core].
+The schema for links added to the <<query-response,links>> and <<query-response,linkTemplates>> sections is based on https://tools.ietf.org/html/rfc8288[RFC 8288] and is described in https://docs.ogc.org/DRAFTS/19-072.html#link-relation-conventions[OGC API - Common - Part 1: Core] and http://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml[OGC API - Features - Part 1: Core].
 
-Links added directly to the <<query-response,properties>> section of a catalog record can be
-added using the following patterns:
+Links added directly to the <<query-response,properties>> section of a catalog record can be added using the following patterns:
 
 . The link relation is the key for an array of links with a schema similar to that used in the <<query-response,links>> section but omitting the `rel` key.
 . The link relation is the key for an array of `href` values.
@@ -815,18 +850,12 @@ The following examples illustrate each of these linking patterns:
 .Adding links to the **links** section
 ----
 {
-   .
-   .
-   .,
+   ...,
    "properties": {
-      .
-      .
-      .,
+      ...,
       "links":
       [
-         .
-         .
-         .,
+         ...,
          {
             "rel" : "alternate",
             "title" : "This records as XML.",
@@ -837,13 +866,9 @@ The following examples illustrate each of these linking patterns:
             "title": "The next record in this result set.",
             "href" : "https://example.org/collections/mycat/items/rec02"
          },
-         .
-         .
-         .
+         ...
       ],
-      .
-      .
-      .
+      ...
    }
 }
 ----
@@ -852,28 +877,26 @@ The following examples illustrate each of these linking patterns:
 .Adding links to the **properties** section
 ----
 {
-   .
-   .
-   .,
-   "properties": {
-      .
-      .
-      .,
-
-      "related": [
-         {
-		      "title" : "A related record",
-		      "href" : "https://example.org/related-record-path/rec15"
-	      }
-      ],
-      "license": {
-		   "title" : "CC BY 2.0",
-		   "href" : "https://creativecommons.org/licenses/by/2.0/"
-	   },
-      .
-      .
-      .
-   }
+  ...,
+  "properties": {
+    ...,
+    "related": [
+      {
+        "title" : "A related record",
+        "href" : "https://example.org/related-record-path/rec15"
+	   }
+    ],
+    "license": {
+      "title" : "CC BY 2.0",
+      "href" : "https://creativecommons.org/licenses/by/2.0/"
+	 },
+    "enclosure": {
+      "title": "GeoPackage of Feature Data",
+￼     "href" : "https://www.someserver.com/collections/MyCollection/items?f=application/geopackage+vnd.sqlite3&bbox={bbox}",
+￼     "varBase": "https://www.someserver.com/variables"
+    },
+    ...
+  }
 }
 ----
 
@@ -881,19 +904,12 @@ The following examples illustrate each of these linking patterns:
 .Adding links to the **properties** section
 ----
 {
-   .
-   .
-   .,
+   ...,
    "properties": {
-      .
-      .
-      .,
-
+      ...,
       "related": ["https://example.org/related-record-path/rec15"],
       "license": "https://creativecommons.org/licenses/by/2.0/",
-      .
-      .
-      .
+      ...
    }
 }
 ----

--- a/core/standard/recommendations/record-core/REC_record-associations_templated.adoc
+++ b/core/standard/recommendations/record-core/REC_record-associations_templated.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/record-core/associations-templated*
 
-If access to the resource(s) requires or would be facilitated by additional context (e.g. a bounding box) then <<sc_templated_links_with_variables,templated links>> (`"templated": true`) should be used.
+If access to the resource(s) requires or would be facilitated by additional context (e.g. a bounding box) then <<sc_templated_links_with_variables,templated links>> SHOULD be used.
 |===

--- a/core/standard/recommendations/record-core/REC_record-links_iana.adoc
+++ b/core/standard/recommendations/record-core/REC_record-links_iana.adoc
@@ -3,5 +3,5 @@
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/record-core/links_iana*
 
-It is recommended to use the official https://www.iana.org/assignments/link-relations/link-relations.xhtml[IANA Link Relation Types] for links in the `links` section.
+It is recommended to use the official https://www.iana.org/assignments/link-relations/link-relations.xhtml[IANA Link Relation Types] for links in the `links` or `linkTemplates` sections.
 |===

--- a/core/standard/recommendations/record-core/REC_templated-link.adoc
+++ b/core/standard/recommendations/record-core/REC_templated-link.adoc
@@ -1,0 +1,8 @@
+[[rec_record-core_templated-link]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/record-core/templated-link*
+
+^|A |A dictionary of substitution variable definitions SHOULD be defined for templated links.
+^|B |The dictionary MAY either be specified in-line in the link using the `variables` member or substitution variable definitions MAY be retrieved by appending the name of the variable to a base URI specified using the `varBase` member.
+|===

--- a/core/standard/requirements/record-core/REQ_templated-link-header.adoc
+++ b/core/standard/requirements/record-core/REQ_templated-link-header.adoc
@@ -1,0 +1,7 @@
+[[req_record-core_templated-link-header]]
+[width="90%",cols="2,6a"]
+|===
+^|*Requirement {counter:req-id}* |*/req/record-core/templated-link-header*
+
+A templated link that appears in a HTTP header SHALL be encoded according to https://ietf-wg-httpapi.github.io/link-template/draft-ietf-httpapi-link-template.html[The Link-Template HTTP Header Field] specification.
+|===

--- a/core/standard/requirements/record-core/REQ_templated-link.adoc
+++ b/core/standard/requirements/record-core/REQ_templated-link.adoc
@@ -7,44 +7,9 @@
 
 [source,YAML]
 ----
-type: object
-required:
-  - href
-  - rel
-properties:
-  href:
-    type: string
-    description: Supplies the URI to a remote resource (or resource fragment).
-    example: http://data.example.com/buildings/123
-  rel:
-    type: string
-    description: The type or semantics of the relation.
-    example: alternate
-  type:
-    type: string
-    description: A hint indicating what the media type of the result of dereferencing the link should be.
-    example: application/geo+json
-  hreflang:
-    type: string
-    description: A hint indicating what the language of the result of dereferencing the link should be.
-    example: en
-  title:
-    type: string
-    description: Used to label the destination of a link such that it can be used as a human-readable identifier.
-    example: Trierer Strasse 70, 53115 Bonn
-  length:
-    type: integer
-  templated:
-    type: boolean
-    description: Used to indicate that the URI of the link is a template that contains substitution variables.
-    default: false
-  variables:
-    type: object
-    description: A dictionary of the JSON Schema fragments defining the characteristics of each substitution variable in the link URI.
+include::../../../openapi/schemas/common/linkTemplate.yaml[]
 ----
 
-^|B |The link template SHALL be encoded as a link object with a property `templated` set to `true` and the URI template in `href`.
+^|B |The `link-template` member SHALL supply the templated link URI.
 ^|C |Substitution variables in the templated link URI SHALL have the form `{_variable name_}`.
-^|D |For each substitution variable in a templated link URI, there SHALL be a correspondingly named entry in the `variables` dictionary.
-^|E |Templated links included in the HTTP header SHALL use the `Link-Template` HTTP header accorinding to the https://datatracker.ietf.org/doc/draft-ietf-httpapi-link-template/[draft "The Link-Template HTTP Header Field" specification] and SHALL forgo the inclusion of the `variables` dictionary.
 |===


### PR DESCRIPTION
Closes #275

The gist of the PR is that client who know nothing about templated links should still be able to resolve the link.

This is accomplished by converting the templated member from a boolean to a string that supplies the text of the parameterized URL. If it is present then the href member simply contains an example or representative URL created by picking valid substitution values from the dictionary of substitution variables.

Aware clients can ignore the href value and generate a new resolvable URL using the dictionary of substitution variables.

Unaware clients can ignore all the templated stuff and simply use the value of the href member.