### PR TITLE
Add preview and enclosure examples.

### DIFF
--- a/core/examples/json/record.json
+++ b/core/examples/json/record.json
@@ -61,7 +61,7 @@
       },
       {
         "code": "fr-CA",
-        "name": French (Canada)"
+        "name": "French (Canada)"
       }
     ],
     "externalId": [

--- a/core/examples/json/record.json
+++ b/core/examples/json/record.json
@@ -191,6 +191,12 @@
       "href": "https://woudc.org/data/dataset_info.php?id=totalozone"
     },
     {
+      "rel": "preview",
+      "type": "image/png",
+      "title": "Total Ozone Preview Image",
+      "href": "https://woudc.org/data/preview.png"
+    },
+    {
       "rel": "enclosure",
       "type": "text/html",
       "title": "Web Accessible Folder (WAF)",


### PR DESCRIPTION
Closes #316.

The example record already included `rel="enclosure"` links so I just added a `rel="preview"` link to illustrate how a record can link to a preview image.