### PR TITLE
Make the "time" member optional to align with STAC.

### DIFF
--- a/core/openapi/schemas/recordGeoJSON.yaml
+++ b/core/openapi/schemas/recordGeoJSON.yaml
@@ -3,7 +3,6 @@ type: object
 required:
   - id
   - type
-  - time
   - geometry
   - properties
   - links

--- a/core/openapi/schemas/recordGeoJSON.yaml
+++ b/core/openapi/schemas/recordGeoJSON.yaml
@@ -21,7 +21,10 @@ properties:
     enum:
       - Feature
   time:
-    $ref: 'time.yaml'
+    oneOf:
+      - enum:
+        - null
+      - $ref: 'time.yaml'
   geometry:
     oneOf:
       - enum:

--- a/core/standard/abstract_tests/record-core/ATS_mandatory-properties-record.adoc
+++ b/core/standard/abstract_tests/record-core/ATS_mandatory-properties-record.adoc
@@ -9,7 +9,6 @@
 . Parse record
 . Check that the record includes an ``id`` property
 . Check that the record includes a ``geometry`` property
-. Check that the record includes a ``time`` property
 . Check that the record includes a ``properties.type`` property
 . Check that the record includes a ``properties.title`` property
 |===

--- a/core/standard/abstract_tests/record-core/ATS_time-instant-interval.adoc
+++ b/core/standard/abstract_tests/record-core/ATS_time-instant-interval.adoc
@@ -4,7 +4,7 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/core/time-instant-interval*
 ^|Test Purpose |Validate the behavior of time instance and intervals in time object.
 ^|Requirement |<<req_core_time-instant-interval,/req/core/time-instant-interval>>
-^|Test Method |. Construct a path for a given record
+^|Test Method |. Construct a path for a given record that includes the `time` member
 . Issue a HTTP GET request on the path
 . Parse time object
 . If the time object includes both a ``date`` and a ``timestamp`` member, check that the `full-date` parts are identical.

--- a/core/standard/abstract_tests/record-core/ATS_time-instant.adoc
+++ b/core/standard/abstract_tests/record-core/ATS_time-instant.adoc
@@ -4,7 +4,7 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/core/time-instant*
 ^|Test Purpose |Validate the behavior of time instances for time objects.
 ^|Requirement |<<req_core_time-instant,/req/core/time-instant>>
-^|Test Method |. Construct a path for a given record
+^|Test Method |. Construct a path for a given record that includes the `time` member
 . Issue a HTTP GET request on the path
 . Parse time object
 . If the time object includes a ``date`` member, check that the value conforms to RFC 3339 (Date and Time on the Internet: Timestamps) and matches the production rule ``full-date``

--- a/core/standard/abstract_tests/record-core/ATS_time-interval.adoc
+++ b/core/standard/abstract_tests/record-core/ATS_time-interval.adoc
@@ -4,7 +4,7 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/core/interval*
 ^|Test Purpose |Validate the behavior of time interval for time objects.
 ^|Requirement |<<req_core_interval,/req/core/interval>>
-^|Test Method |. Construct a path for a given record
+^|Test Method |. Construct a path for a given record that includes the `time` member
 . Issue a HTTP GET request on the path
 . Parse time object
 . If the time object includes an ``interval`` member, check that each array item is a string that is a double-dot (``..``) or conforms to RFC 3339 (Date and Time on the Internet: Timestamps) and matches one of the following production rules: ``full-date`` (a date) or ``date-time`` (a timestamp)

--- a/core/standard/abstract_tests/record-core/ATS_time-zone.adoc
+++ b/core/standard/abstract_tests/record-core/ATS_time-zone.adoc
@@ -4,7 +4,7 @@
 ^|*Abstract Test {counter:ats-id}* |*/conf/core/time-zone*
 ^|Test Purpose |Validate the behavior of time zone for time member.
 ^|Requirement |<<req_core_time-zone,/req/core/time-zone>>
-^|Test Method |. Construct a path for a given record
+^|Test Method |. Construct a path for a given record that includes the `time` member
 . Issue a HTTP GET request on the path
 . Parse time member
 . Check that timestamps in the time member use UTC "Z" as the time zone.

--- a/core/standard/abstract_tests/searchable-catalog/ATS_mandatory-properties.adoc
+++ b/core/standard/abstract_tests/searchable-catalog/ATS_mandatory-properties.adoc
@@ -9,7 +9,6 @@
 . Parse record
 . Check that the record includes an ``id`` property
 . Check that the record includes a ``geometry`` property
-. Check that the record includes a ``time`` property
 . Check that the record includes a ``properties.type`` property
 . Check that the record includes a ``properties.title`` property
 |===

--- a/core/standard/abstract_tests/searchable-catalog_filtering/ATS_mandatory-queryables.adoc
+++ b/core/standard/abstract_tests/searchable-catalog_filtering/ATS_mandatory-queryables.adoc
@@ -8,7 +8,6 @@
 . Issue an HTTP GET request on the path
 . Check that the list of queryables includes a ``recordId`` property
 . Check that the list of queryables includes a ``geometry`` property
-. Check that the list of queryables includes a ``time`` property
 . Check that the list of queryables includes a ``type`` property
 . Check that the list of queryables includes a ``title`` property
 |===

--- a/core/standard/clause_6_overview.adoc
+++ b/core/standard/clause_6_overview.adoc
@@ -39,7 +39,7 @@ A special use case of the _searchable catalog_ is the _**local resources catalog
 === Record Schema
 
 The core set of record properties that may be used to describe a resource
-include the  _recordId_, _time_, _type_, _title_, _description_ and _geometry_.
+include the  _recordId_, _type_, _title_, _description_ and _geometry_.
 A complete definition of a record can be found in clause <<core-properties,Core properties>>.
 
 The choice of which properties to include in the set of core properties was primarily informed by the following record models:

--- a/core/standard/clause_7_building_blocks.adoc
+++ b/core/standard/clause_7_building_blocks.adoc
@@ -51,9 +51,9 @@ Other encodings are allowed but are not described in this document.
 |===
 |Property |Requirement |Description |GeoJSON key
 |geometry |**required** |A geometry associated with the resource that is used for discovery.  Can be null if there is no associated geometry. |`geometry`
-|time |**required** |The temporal extent of the resource. Can be null if there is no associated temporal extent. |`time`
 |type |**required** |The nature or genre of the resource. |`properties.type`
 |title |**required** |A human-readable name given to the resource. |`properties.title`
+|time |optional |The temporal extent of the resource. Can be null if there is no associated temporal extent. |`time`
 |description |optional |A free-text description of the resource. |`properties.description`
 |keywords |optional |A list of free-form keywords or tags associated with the resource. |`properties.keywords`
 |language |optional |The language used for textual values (i.e. titles, descriptions, etc.) of this record. |`properties.language`
@@ -99,7 +99,11 @@ Records can have multiple properties that describe the temporal characteristics 
 
 * Multiple temporal properties are sometimes used to describe different temporal characteristics of the resource(s) the record describes. For example, the time instant or interval when the information in the record is valid (sometimes called "valid time") and the time when the record was recorded in the catalog (sometimes called "transaction time"). Another example is the https://www.ogc.org/standards/om[Observations & Measurements standard], where an observation has multiple temporal properties including "phenomenon time", "result time" and "valid time".
 
-This Standard does not place any constraints on the number of additional temporal properties that may be added to a record to characterize temporal aspects of the resource being described by a record.  This can make it difficult for a naive client to recognize and utilize temporal information stored in the record.  For this reason, this Standard includes the `time` property in a record.  This `time` member is set by the publisher of the record and describes characteristic temporal information (an instant or an interval) associated with the resource described by a record.   This `time` member can thus be used by naive clients without the need to inspect or understand the schema of an extended record.  The value of the `time` member is either `null` (no temporal information) or an object encoding a time instant or interval.
+This Standard does not place any constraints on the number of additional temporal properties that may be added to a record to characterize temporal aspects of the resource being described by a record.  This can make it difficult for a naive client to recognize and utilize temporal information stored in the record.  For this reason, this Standard includes the `time` property in a record.  
+
+include::recommendations/record-core/REC_time.adoc[]
+
+This `time` member is set by the publisher of the record and describes characteristic temporal information (an instant or an interval) associated with the resource described by a record.   This `time` member can thus be used by naive clients without the need to inspect or understand the schema of an extended record.  If included in the record, the value of the `time` member is either `null` (no temporal information) or an object encoding a time instant or interval.
 
 .Properties of the "time" object
 [cols="20,10a,70a",options="header"]

--- a/core/standard/recommendations/record-core/PER_temporal_comparison.adoc
+++ b/core/standard/recommendations/record-core/PER_temporal_comparison.adoc
@@ -2,5 +2,5 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/record-core/temporal-comparison*
-^|A |`date` and `timestamp` are different datatypes and when attempting to compare them, a server MAY either return an error or it MAY case the value to compatible data types for comparison.
+^|A |`date` and `timestamp` are different datatypes and when attempting to compare them, a server MAY either return an error or it MAY cast the value(s) to compatible data types for comparison.
 |===

--- a/core/standard/recommendations/record-core/REC_time.adoc
+++ b/core/standard/recommendations/record-core/REC_time.adoc
@@ -2,6 +2,6 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Recommendation {counter:rec-id}* |*/rec/core/record-contact*
-^|A |A record SHOULD include the top-level `time` member that indicates some characteristic temporal aspect of the resource that the record describes.
-^|B |If such chracteristic temporal information about the resource is not available then the `time` member SHOULD, even though it is optional, still be included in the record and its values SHOULD be set to `null`.
+^|A |A record SHOULD include the top-level `time` member that indicates the temporal aspect of the resource that the record describes.
+^|B |If temporal information about the resource is not available then the `time` member SHOULD, even though it is optional, still be included in the record and its value SHOULD be set to `null`.
 |===

--- a/core/standard/recommendations/record-core/REC_time.adoc
+++ b/core/standard/recommendations/record-core/REC_time.adoc
@@ -1,0 +1,7 @@
+[[rec_record-core_time]]
+[width="90%",cols="2,6a"]
+|===
+^|*Recommendation {counter:rec-id}* |*/rec/core/record-contact*
+^|A |A record SHOULD include the top-level `time` member that indicates some characteristic temporal aspect of the resource that the record describes.
+^|B |If such chracteristic temporal information about the resource is not available then the `time` member SHOULD, even though it is optional, still be included in the record and its values SHOULD be set to `null`.
+|===


### PR DESCRIPTION
In STAC, the time member is optional so, in order to promote more alignment between the two standards (since we want STAC to be a profile of Records), I've made the changes to make the top-level `time` member optional.  I did, however, add a recommendation that says that the `time` member shoud be included in the record.