### PR TITLE
Fix typo in Table 2.  Record collection is Mandatory for Local Resources Catalog.

### DIFF
--- a/core/standard/clause_2_conformance.adoc
+++ b/core/standard/clause_2_conformance.adoc
@@ -105,7 +105,7 @@ The <<clause-local-resources-catalog,Local Resources Catalog>>, <<clause-local-r
 |Common Component 3+|Catalog requirements class
 | |<<clause-crawlable-catalog,_**Crawlable**_>> |<<clause-searchable-catalog,_**Searchable**_>> |<<clause-local-resources-catalog,_**Local Resources catalog**_>>
 |<<clause-record-core,Record Core>> |Mandatory |Mandatory |Mandatory
-|<<clause-record-collection,Record collection>> |Optional |Mandatory |N/A
+|<<clause-record-collection,Record collection>> |Optional |Mandatory |Mandatory
 |<<clause-record-core-query-parameters,Record query parameters>> |N/A |Mandatory |Optional
 |<<clause-records-api,Records API>> |N/A |Mandatory |N/A
 |<<clause-sorting,Sorting>> |N/A |Optional |Optional


### PR DESCRIPTION
Table 2 inidicates N/A for "Record Collection" and "Local Resources Catalog".  This is incorrect.  The correct value should be Mandatory.