### PR TITLE
Resolve issue #398.

### DIFF
--- a/core/openapi/ogcapi-records-1-building-blocks.yaml
+++ b/core/openapi/ogcapi-records-1-building-blocks.yaml
@@ -134,86 +134,80 @@ components:
       explode: false
       style: form
   schemas:
-    catalogs:
-      allOf:
-        - $ref: '#/components/schemas/collections'
-        - type: object
-          properties:
-            collections:
-              type: array
-              items:
-                $ref: '#/components/schemas/catalog'
-            linkTemplates:
-              type: array
-              items:
-                $ref: '#/components/schemas/linkTemplate'
     catalog:
       allOf:
-        - $ref: "#/components/schemas/collection"
+        - $ref: '#/components/schemas/collection'
+        - $ref: '#/components/schemas/recordCommonProperties'
         - type: object
           required:
-            - title
             - type
-            - itemType
           properties:
-            type:
-              type: string
-              enum:
-                - catalog
             itemType:
+              description:
+                If this catalog is a homogenous collection
+                of records then itemType is a string of fixed
+                value of record.
+                If this catalog is a homogenous collection
+                of other catalogs then itemType is a string of
+                fixed value of catalog.
+                If this catalog is a heterogenous collection
+                of records and catalogs then itemType is a array
+                indicated that item types of the members of this
+                collections (i.e. record and/or catalog).
               oneOf:
                 - type: string
                   enum:
                     - record
+                    - catalog
                 - type: array
                   items:
                     type: string
-                    enum:
+                    enum: 
                       - record
                       - catalog
-                      - collection
-                      - other
+            type:
+              descripton:
+                Fixed to catalog for collections of records
+                and/or subordinate catalogs.
+              type: string
+              enum:
+                - Catalog
             conformsTo:
-              $ref: "#/components/schemas/confClasses"
-            created:
-              type: string
-              format: date-time
-            updated:
-              type: string
-              format: date-time
-            keywords:
               type: array
+              description:
+                The extensions/conformance classes used in this record.
               items:
                 type: string
-            language:
-              $ref: "#/components/schemas/language"
-            languages:
-              type: array
-              items:
-                $ref: "#/components/schemas/language"
-            themes:
-              type: array
-              minItems: 1
-              items:
-                $ref: "#/components/schemas/theme"
-            contacts:
-              type: array
-              items:
-                $ref: "#/components/schemas/contact"
-            license:
-              $ref: "#/components/schemas/license"
-            rights:
+            recordsArrayName:
               type: string
-            defaultSortOrder:
+              default:
+                - records
+            records:
+              type: array
+              description: 
+                 An array of records that are part of this catalog that
+                 are encoded in-line with the catalog.
+              items:
+                $ref: '#/components/schemas/recordGeoJSON'
+            links:
               type: array
               items:
-                type: string
+                $ref: '#/components/schemas/link'
             linkTemplates:
               type: array
-              items: 
+              items:
                 $ref: '#/components/schemas/linkTemplate'
+            schemes:
+              type: array
+              description:
+                A list of schemes used in this context.
+              items:
+                $ref: '#/components/schemas/scheme'
     contact:
       type: object
+      description: |-
+        Identification of, and means of communication with, person responsible
+        for the resource.
       anyOf:
         - required:
           - name
@@ -222,15 +216,27 @@ components:
       properties:
         identifier:
           type: string
+          description: |-
+            A value uniquely identifying a contact.
         name:
           type: string
+          description: |-
+            The name of the responsible person.
         position:
           type: string
+          description:
+            The name of the role or position of the responsible person taken
+            from the organization's formal organizational hierarchy or chart.
         organization:
           type: string
+          description:
+            Organization/affiliation of the contact.
         logo:
+          description:
+            Graphic identifying a contact. The link relation should be `icon`
+            and the media type should be an image media type.
           allOf:
-            - $ref: "#/components/schemas/link"
+            - $ref: '#/components/schemas/link' 
             - type: object
               required:
                 - rel
@@ -241,6 +247,7 @@ components:
                     - icon
         phones:
           type: array
+          description: Telephone numbers at which contact can be made.
           items:
             type: object
             required:
@@ -253,9 +260,12 @@ components:
                 examples:
                   - "+14165550142"
               roles:
-                $ref: "#/components/schemas/roles"
+                description:
+                  The type of phone number (e.g. home, work, fax, etc.).
+                $ref: '#/components/schemas/roles'
         emails:
           type: array
+          description: Email addresses at which contact can be made.
           items:
             type: object
             required:
@@ -263,81 +273,129 @@ components:
             properties:
               value:
                 type: string
+                description: The value is the email number itself.
                 format: email
               roles:
-                $ref: "#/components/schemas/roles"
+                description:
+                  The type of email (e.g. home, work, etc.).
+                $ref: '#/components/schemas/roles'
         addresses:
           type: array
+          description: Physical location at which contact can be made.
           items:
             type: object
             properties:
               deliveryPoint:
-      
                 type: array
+                description: Address lines for the location.
                 items:
                   type: string
               city:
                 type: string
+                description: City for the location.
               administrativeArea:
                 type: string
+                description: State or province of the location.
               postalCode:
                 type: string
+                description: ZIP or other postal code.
               country:
                 type: string
+                description: Country of the physical address.  ISO 3166-1 is recommended.
               roles:
-                $ref: "#/components/schemas/roles"
+                description:
+                  The type of address (e.g. office, home, etc.).
+                $ref: '#/components/schemas/roles'
         links:
           type: array
+          description: On-line information about the contact.
           items:
             allOf:
-              - $ref: "#/components/schemas/link"
+              - $ref: '#/components/schemas/link'
               - type: object
                 required:
                   - type
         hoursOfService:
           type: string
+          description: Time period when the contact can be contacted.
           examples:
             - "Hours: Mo-Fr 10am-7pm Sa 10am-22pm Su 10am-21pm"
         contactInstructions:
           type: string
+          description: |-
+            Supplemental instructions on how or when to contact the
+            responsible party.
         roles:
-          $ref: "#/components/schemas/roles"
-    featureCollectionGeoJSONRecords:
-      allOf:
-        - $ref: '#/components/schemas/featureCollectionGeoJSON'
-        - type: object
-          properties:
-            features:
-              type: array
-              items:
-                $ref: '#/components/schemas/recordGeoJSON'
-            linkTemplates:
-              type: array
-              items:
-                $ref: '#/components/schemas/linkTemplate'
-    landingPageRecords:
-      allOf:
-        - $ref: '#/components/schemas/landingPage'
-        - type: object
-          properties:
-            linksTemplates:
-              type: array
-              items:
-                $ref: '#/components/schemas/linkTemplate'
+          description:
+            The set of named duties, job functions and/or permissions
+            associated with this contact.
+            (e.g. developer, administrator, etc.).
+          $ref: '#/components/schemas/roles'
+    format:
+      type: object
+      anyOf:
+      - required:
+        - name
+      - required:
+        - mediaType
+      properties:
+        name:
+          type: string
+        mediaType:
+          type: string
+    landingPage:
+      type: object
+      required:
+        - links
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+        linkTemplates:
+          type: array
+          items:
+            $ref: '#/components/schemas/linkTemplate'
     language:
       type: object
+      description:
+        The language used for textual values in this record.
       required:
         - code
       properties:
         code:
           type: string
+          description:
+            The language tag as per RFC-5646.
+          examples:
+            - "el"
         name:
           type: string
           minLength: 1
+          description:
+            The untranslated name of the language.
+          examples:
+            - "Ελληνικά"
         alternate:
           type: string
+          description:
+            The name of the language in another well-understood language,
+            usually English.
+          examples:
+            - "Greek"
         dir:
           type: string
+          description:
+            The direction for text in this language. The default, `ltr`
+            (left-to-right), represents the most common situation.
+            However, care should be taken to set the value of `dir`
+            appropriately if the language direction is not `ltr`.
+            Other values supported are `rtl` (right-to-left), `ttb`
+            (top-to-bottom), and `btt` (bottom-to-top).
           enum:
             - ltr
             - rtl
@@ -346,150 +404,281 @@ components:
           default: ltr
     license:
       type: string
+      description:
+        A legal document under which the resource is made available.
+        If the resource is being made available under a common license
+        then use an SPDX license id (https://spdx.org/licenses/).
+        If the resource is being made available under multiple common
+        licenses then use an SPDX license expression v2.3 string
+        (https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/)
+        If the resource is being made available under one or more licenses
+        that haven't been assigned an SPDX identifier or one or more custom
+        licenses then use a string value of 'other' and include one or more
+        links (rel="license") in the `link` section of the record to the
+        file(s) that contains the text of the license(s).
+        There is also the case of a resource that is private or unpublished
+        and is thus unlicensed; in this case do not register such a resource
+        in the catalog in the first place since there is no point in making
+        such a resource discoverable.
     linkBase:
       type: object
       properties:
         rel:
           type: string
-          examples:
-            - "alternate"
+          description: The type or semantics of the relation.
+          example: "alternate"
         type:
           type: string
-          examples:
-            - "application/geo+json"
+          description:
+            A hint indicating what the media type of the
+            result of dereferencing the link should be.
+          example: "application/geo+json"
         hreflang:
           type: string
-          examples:
-            - "en"
+          description:
+            A hint indicating what the language of the
+            result of dereferencing the link should be.
+          example: "en"
         title:
           type: string
-          examples:
-            - "Trierer Strasse 70, 53115 Bonn"
+          description:
+            Used to label the destination of a link
+            such that it can be used as a human-readable
+            identifier.
+          example: "Trierer Strasse 70, 53115 Bonn"
         length:
           type: integer
         created:
           type: string
+          description:
+            Date of creation of the resource pointed to
+            by the link.
           format: date-time
         updated:
           type: string
+          description:
+            Most recent date on which the resource pointed
+            to by the link was changed.
           format: date-time
     linkTemplate:
       allOf:
-        - $ref: "#/components/schemas/linkBase"
+        - $ref: '#/components/schemas/linkBase'
         - type: object
-          required: 
-            - linkTemplate
-          properties:
+          required:
+            - uriTemplate
+          properties: 
             uriTemplate:
               type: string
-              examples:
-                - "https://example.org/data/buildings/{building-id}"
-            variables:
-              type: object
+              description:
+                Supplies a resolvable URI to a remote resource
+                (or resource fragment).
+              example: "http://data.example.com/buildings/(building-id}"
             varBase:
               type: string
+              description:
+                The base URI to which the variable name can be
+                appended to retrieve the definition of the
+                variable as a JSON Schema fragment.
               format: uri
+            variables:
+              type: object
+              description:
+                This object contains one key per substitution
+                variable in the templated URL.  Each key defines
+                the schema of one substitution variable using a
+                JSON Schema fragment and can thus include things
+                like the data type of the variable, enumerations,
+                minimum values, maximum values, etc.
+    link:
+      allOf:
+        - $ref: '#/components/schemas/linkBase'
+        - type: object
+          required:
+            - href
+          properties:
+            href:
+              type: string
+              format: uri
+    recordCommonProperties:
+      type: object
+      properties:
+        created:
+          type: string
+          description:
+            The date this record was created in the server.
+          format: date-time
+        updated:
+          type: string
+          description:
+            The most recent date on which the record was changed.
+          format: date-time
+        type:
+          type: string
+          description:
+            The nature or genre of the resource. The value
+            should be a code, convenient for filtering
+            records. Where available, a link to the canonical
+            URI of the record type resource will be added to
+            the 'links' property.
+        title:
+          type: string
+          description:
+            A human-readable name given to the resource.
+        description:
+          type: string
+          description:
+            A free-text account of the resource.
+        keywords:
+          type: array
+          description:
+            The topic or topics of the resource. Typically
+            represented using free-form keywords, tags, key
+            phrases, or classification codes.
+          items:
+            type: string
+        themes:
+          type: array
+          description:
+            A knowledge organization system used to classify
+            the resource.
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/theme'
+        language:
+          description:
+            The language used for textual values in this
+            record representation.
+          $ref: '#/components/schemas/language'
+        languages:
+          type: array
+          description:
+            This list of languages in which this record is
+            available.
+          items:
+            $ref: '#/components/schemas/language'
+        resourceLanguages:
+          type: array
+          description:
+            The list of languages in which the resource
+            described by this record is available.
+          items:
+            $ref: '#/components/schemas/language'
+        externalIds:
+          type: array
+          description:
+            An identifier for the resource assigned by an
+            external (to the catalog) entity.
+          items:
+            type: object
+            properties:
+              scheme:
+                type: string
+                description:
+                  A reference to an authority or identifier
+                  for a knowledge organization system from
+                  which the external identifier was obtained.
+                  It is recommended that the identifier be a
+                  resolvable URI.
+              value:
+                type: string
+                description: The value of the identifier.
+            required:
+              - value
+        formats:
+          type: array
+          description:
+            A list of available distributions of the resource.
+          items:
+            $ref: '#/components/schemas/format'
+        contacts:
+          type: array
+          description:
+            A list of contacts qualified by their role(s) in
+            association to the record or the resource described
+            by the record.
+          items:
+            $ref: '#/components/schemas/contact'
+        license:
+          $ref: '#/components/schemas/license'
+        rights:
+          type: string
+          description:
+            A statement that concerns all rights not addressed
+            by the license such as a copyright statement.
     recordGeoJSON:
       type: object
       required:
         - id
         - type
-        - time
         - geometry
         - properties
-        - links
       properties:
         id:
           type: string
-        conformsTo:
-          type: array
-          items:
-            type: string
+          description:
+            A unique identifier of the catalog record.
         type:
           type: string
           enum:
             - Feature
         time:
-          $ref: "#/components/schemas/time"
+          oneOf:
+            - enum:
+              - null
+            - $ref: '#/components/schemas/time'
         geometry:
           oneOf:
             - enum:
               - null
-            - $ref: "#/components/schemas/geometryGeoJSON"
+            - $ref: '#/components/schemas/geometryGeoJSON'
+        conformsTo:
+          type: array
+          description:
+            The extensions/conformance classes used in this record.
+          items:
+            type: string
         properties:
-          type: object
-          required:
-            - type
-            - title
-          properties:
-            created:
-              type: string
-              format: date-time
-            updated:
-              type: string
-              format: date-time
-            type:
-              type: string
-              maxLength: 64
-            title:
-              type: string
-            description:
-              type: string
-            keywords:
-              type: array
-              items:
-                type: string
-            language:
-              $ref: "#/components/schemas/language"
-            languages:
-              type: array
-              items:
-                $ref: "#/components/schemas/language"
-            resourceLanguages:
-              type: array
-              items:
-                $ref: "#/components/schemas/language"
-            externalIds:
-              type: array
-              items:
-                type: object
-                properties:
-                  scheme:
-                    type: string
-                  value:
-                    type: string
-                required:
-                  - value
-            themes:
-              type: array
-              minItems: 1
-              items:
-                $ref: "#/components/schemas/theme"
-            formats:
-              type: array
-              items:
-                type: string
-            contacts:
-              type: array
-              items:
-                $ref: "#/components/schemas/contact"
-            license:
-              $ref: "#/components/schemas/license"
-            rights:
-              type: string
-            links:
-              type: array
-              items:
-                $ref: '#/components/schemas/link'
-            linkTemplates:
-              type: array
-              items:
-                $ref: '#/components/schemas/linkTemplate'
+          allOf:
+            - $ref: '#/components/schemas/recordCommonProperties'
+            - type:
+                object
+        links:
+          type: array
+          items:
+            $ref: '#/components/schemas/link'
+        linkTemplates:
+          type: array
+          items:
+            $ref: '#/components/schemas/linkTemplate'
     roles:
+      description:
+        The list of duties, job functions or permissions assigned by the system
+        and associated with the context of this member.
       type: array
       minItems: 1
       items:
         type: string
+    scheme:
+      type: object
+      required:
+        - scheme-id 
+        - namespace
+      properties:
+        scheme-id:
+          type: string
+          description:
+            An identifier for this namespace.  The identifier can be used as a 
+            short-form for the namespace.
+        namespace:
+          type: string
+          description:
+            A declarative region that provides a scope to the identifiers
+            inside it. It is recommended that the value of namespace be a URI.
+        resolver:
+          description:
+            An extensible description of a mechanism that resolves a scheme
+            identifier (scheme-id) to its namespace.
+          type: object
     theme:
       type: object
       required:
@@ -498,6 +687,10 @@ components:
       properties:
         concepts:
           type: array
+          description:
+            One or more entity/concept identifiers from this knowledge
+            system. it is recommended that a resolvable URI be used for
+            each entity/concept identifier.
           minItems: 1
           items:
             type: object
@@ -506,15 +699,28 @@ components:
             properties:
               id:
                 type: string
+                description: An identifier for the concept.
               title:
                 type: string
+                description: A human readable title for the concept.
               description:
                 type: string
+                description: A human readable description for the concept.
               url:
                 type: string
                 format: uri
+                description: A URI providing further description of the concept.
         scheme:
           type: string
+          description:
+            An identifier for the knowledge organization system used
+            to classify the resource.  It is recommended that the
+            identifier be a resolvable URI.  The list of schemes used
+            in a searchable catalog can be determined by inspecting
+            the server's OpenAPI document or, if the server implements
+            CQL2, by exposing a queryable (e.g. named `scheme`) and
+            enumerating the list of schemes in the queryable's schema
+            definition.
     time:
       type: object
       nullable: true
@@ -540,8 +746,20 @@ components:
                   - ".."
         resolution:
           type: string
+          description:
+            Minimum time period resolvable in the dataset, as an
+            ISO 8601 duration.
           examples:
             - "P1D"
+    exception:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+        description:
+          type: string
     collections:
       type: object
       required:
@@ -566,17 +784,17 @@ components:
           description: identifier of the collection used, for example, in URIs
           type: string
           examples:
-            - "address"
+            - address
         title:
           description: human readable title of the collection
           type: string
           examples:
-            - "address"
+            - address
         description:
           description: a description of the features in the collection
           type: string
           examples:
-            - "An address."
+            - An address.
         links:
           type: array
           items:
@@ -590,53 +808,97 @@ components:
         extent:
           $ref: '#/components/schemas/extent'
         itemType:
-          description:
-            indicator about the type of the items in the collection (the
-            default value is 'feature').
+          description: indicator about the type of the items in the collection (the default value is 'feature').
           type: string
           default: feature
         crs:
-          description:
-            the list of coordinate reference systems supported by the service
+          description: the list of coordinate reference systems supported by the service
           type: array
           items:
             type: string
           default:
-            - "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
           examples:
-            - "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
-            - "http://www.opengis.net/def/crs/EPSG/0/4326"
-    confClasses:
-      type: object
-      required:
-        - conformsTo
-      properties:
-        conformsTo:
-          type: array
-          items:
-            type: string
-    exception:
-      type: object
-      required:
-        - code
-      properties:
-        code:
-          type: string
-        description:
-          type: string
+            - http://www.opengis.net/def/crs/OGC/1.3/CRS84
+            - http://www.opengis.net/def/crs/EPSG/0/4326
     extent:
+      description:
+        The extent of the features in the collection. In the Core only spatial
+        and temporal extents are specified. Extensions may add additional
+        members to represent other extents, for example, thermal or pressure
+        ranges.
+
+        An array of extents is provided for each extent type (spatial,
+        temporal). The first item in the array describes the overall extent of
+        the data. All subsequent items describe more precise extents, e.g.,
+        to identify clusters of data. Clients only interested in the overall
+        extent will only need to access the first extent in the array.
       type: object
       properties:
         spatial:
+          description:
+            The spatial extent of the features in the collection.
           type: object
           properties:
             bbox:
+              description: |-
+                One or more bounding boxes that describe the spatial extent
+                of the dataset.  In the Core only a single bounding box is
+                supported.
+                
+                Extensions may support additional areas.
+                The first bounding box describes the overall spatial
+                extent of the data. All subsequent bounding boxes describe
+                more precise bounding boxes, e.g., to identify clusters of data.
+                Clients only interested in the overall spatial extent will
+                only need to access the first bounding box in the array.
               type: array
               minItems: 1
               items:
+                description: |-
+                  Each bounding box is provided as four or six numbers,
+                  depending on whether the coordinate reference system
+                  includes a vertical axis (height or depth)
+
+                  * Lower left corner, coordinate axis 1
+                  * Lower left corner, coordinate axis 2
+                  * Minimum value, coordinate axis 3 (optional)
+                  * Upper right corner, coordinate axis 1
+                  * Upper right corner, coordinate axis 2
+                  * Maximum value, coordinate axis 3 (optional)
+      
+                  If the value consists of four numbers, the coordinate
+                  reference system is WGS 84 longitude/latitude
+                  (http://www.opengis.net/def/crs/OGC/1.3/CRS84)
+                  unless a different coordinate reference system is specified
+                  in `crs`.
+      
+                  If the value consists of six numbers, the coordinate
+                  reference system is WGS 84 longitude/latitude/ellipsoidal
+                  height (http://www.opengis.net/def/crs/OGC/0/CRS84h)
+                  unless a different coordinate reference system is specified
+                  in `crs`.
+      
+                  For WGS 84 longitude/latitude the values are in most cases
+                  the sequence of minimum longitude, minimum latitude, maximum
+                  longitude and maximum latitude.  However, in cases where the
+                  box spans the antimeridian the first value (west-most box
+                  edge) is larger than the third value (east-most box edge).
+      
+                  If the vertical axis is included, the third and the sixth
+                  number are the bottom and the top of the 3-dimensional
+                  bounding box.
+      
+                  If a feature has multiple spatial geometry properties, it is
+                  the decision of the server whether only a single spatial
+                  geometry property is used to determine the extent or all
+                  relevant geometries.
                 type: array
-                minItems: 4
-                maxItems: 6
+                oneOf:
+                - minItems: 4
+                  maxItems: 4
+                - minItems: 6
+                  maxItems: 6
                 items:
                   type: number
                 examples:
@@ -645,17 +907,47 @@ components:
                     - 180
                     - 90
             crs:
+              description:
+                Coordinate reference system of the coordinates in the spatial
+                extent (property `bbox`). The default reference system is WGS
+                84 longitude/latitude. In the Core the only other supported
+                coordinate reference system is WGS 84 longitude/latitude/
+                ellipsoidal height for coordinates with height. Extensions
+                may support additional coordinate reference systems and add
+                additional enum values.
               type: string
               enum:
                 - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+                - 'http://www.opengis.net/def/crs/OGC/0/CRS84h'
               default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
         temporal:
+          description:
+            The temporal extent of the features in the collection.
           type: object
           properties:
             interval:
+              description:
+                One or more time intervals that describe the temporal extent
+                of the dataset. In the Core only a single time interval is
+                supported.
+                
+                Extensions may support multiple intervals. The first time
+                interval describes the overall temporal extent of the data.
+                All subsequent time intervals describe more precise time
+                intervals, e.g., to identify clusters of data. Clients only
+                interested in the overall temporal extent will only need
+                to access the first time interval in the array (a pair of
+                lower and upper bound instants).
               type: array
               minItems: 1
               items:
+                description: |-
+                  Begin and end times of the time interval. The timestamps are
+                  in the temporal coordinate reference system specified in
+                  `trs`. By default this is the Gregorian calendar.
+                  
+                  The value `null` at start or end is supported and indicates
+                  a half-bounded interval.
                 type: array
                 minItems: 2
                 maxItems: 2
@@ -666,9 +958,14 @@ components:
                 examples:
                   - '2011-11-11T12:22:11Z'
                   - null
-            resolution:
-                type: string
             trs:
+              description: |-
+                Coordinate reference system of the coordinates in the temporal
+                extent (property `interval`). The default reference system is
+                the Gregorian calendar. In the Core this is the only supported
+                temporal coordinate reference system. Extensions may support
+                additional temporal coordinate reference systems and add
+                additional enum values.
               type: string
               enum:
                 - 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
@@ -686,11 +983,15 @@ components:
         features:
           type: array
           items:
-            $ref: '#/components/schemas/recordGeoJSON'
+            $ref: '#/components/schemas/featureGeoJSON'
         links:
           type: array
           items:
             $ref: '#/components/schemas/link'
+        linkTemplates:
+          type: array
+          items:
+            $ref: '#/components/schemas/linkTemplate'
         timeStamp:
           type: string
           format: date-time
@@ -700,29 +1001,75 @@ components:
         numberReturned:
           type: integer
           minimum: 0
-    geometrycollectionGeoJSON:
+    featureGeoJSON:
       type: object
       required:
         - type
-        - geometries
+        - geometry
+        - properties
       properties:
         type:
           type: string
           enum:
-            - GeometryCollection
-        geometries:
+            - Feature
+        geometry:
+          $ref: '#/components/schemas/geometryGeoJSON'
+        properties:
+          type: object
+          nullable: true
+        id:
+          oneOf:
+            - type: string
+            - type: integer
+        links:
           type: array
           items:
-            $ref: "#/components/schemas/geometryGeoJSON"
+            $ref: '#/components/schemas/link'
+        linkTemplates:
+          type: array
+          items:
+            $ref: '#/components/schemas/linkTemplate'
     geometryGeoJSON:
       oneOf:
-        - $ref: "#/components/schemas/pointGeoJSON"
-        - $ref: "#/components/schemas/multipointGeoJSON"
-        - $ref: "#/components/schemas/linestringGeoJSON"
-        - $ref: "#/components/schemas/multilinestringGeoJSON"
-        - $ref: "#/components/schemas/polygonGeoJSON"
-        - $ref: "#/components/schemas/multipolygonGeoJSON"
-        - $ref: "#/components/schemas/geometrycollectionGeoJSON"
+        - $ref: '#/components/schemas/pointGeoJSON'
+        - $ref: '#/components/schemas/multipointGeoJSON'
+        - $ref: '#/components/schemas/linestringGeoJSON'
+        - $ref: '#/components/schemas/multilinestringGeoJSON'
+        - $ref: '#/components/schemas/polygonGeoJSON'
+        - $ref: '#/components/schemas/multipolygonGeoJSON'
+        - $ref: '#/components/schemas/geometrycollectionGeoJSON'
+    pointGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - Point
+        coordinates:
+          type: array
+          minItems: 2
+          items:
+            type: number
+    multipointGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
     linestringGeoJSON:
       type: object
       required:
@@ -741,31 +1088,6 @@ components:
             minItems: 2
             items:
               type: number
-    landingPage:
-      type: object
-      required:
-        - links
-      properties:
-        title:
-          type: string
-        description:
-          type: string
-        links:
-          type: array
-          items:
-            $ref: '#/components/schemas/link'
-    link:
-      allOf:
-        - $ref: "#/components/schemas/linkBase"
-        - type: object
-          required:
-            - href
-          properties:
-            href:
-              type: string
-              format: uri
-              examples:
-                - "https://example.org/data/buildings/123"
     multilinestringGeoJSON:
       type: object
       required:
@@ -786,60 +1108,6 @@ components:
               minItems: 2
               items:
                 type: number
-    multipointGeoJSON:
-      type: object
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - MultiPoint
-        coordinates:
-          type: array
-          items:
-            type: array
-            minItems: 2
-            items:
-              type: number
-    multipolygonGeoJSON:
-      type: object
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - MultiPolygon
-        coordinates:
-          type: array
-          items:
-            type: array
-            items:
-              type: array
-              minItems: 4
-              items:
-                type: array
-                minItems: 2
-                items:
-                  type: number
-    pointGeoJSON:
-      type: object
-      required:
-        - type
-        - coordinates
-      properties:
-        type:
-          type: string
-          enum:
-            - Point
-        coordinates:
-          type: array
-          minItems: 2
-          items:
-            type: number
     polygonGeoJSON:
       type: object
       required:
@@ -860,15 +1128,44 @@ components:
               minItems: 2
               items:
                 type: number
+    multipolygonGeoJSON:
+      type: object
+      required:
+        - type
+        - coordinates
+      properties:
+        type:
+          type: string
+          enum:
+            - MultiPoint
+        coordinates:
+          type: array
+          items:
+            type: array
+            minItems: 2
+            items:
+              type: number
+    geometrycollectionGeoJSON:
+       type: object
+       required:
+         - type
+         - geometries
+       properties:
+         type:
+           type: string
+           enum:
+             - GeometryCollection
+         geometries:
+           type: array
+           items:
+             $ref: '#/components/schemas/geometryGeoJSON'
   responses:
     LandingPage:
       description:
-        The landing page provides links to the API definition
-        (link relations `service-desc` and `service-doc`),
-        the Conformance declaration (path `/conformance`,
-        link relation `conformance`), and the Feature
-        Collections (path `/collections`, link relation
-        `data`).
+        The landing page provides links to the API definition (link relations
+        `service-desc` and `service-doc`), the Conformance declaration (path
+        `/conformance`, link relation `conformance`), and the Record Collections
+        (path `/collections`, link relation `data`).
       content:
         application/json:
           schema:
@@ -878,28 +1175,21 @@ components:
             type: string
     ConformanceDeclaration:
       description:
-        The URIs of all conformance classes supported by the server. 
-        To support "generic" clients that want to access multiple
-        OGC API Features implementations - and not "just" a specific
-        API / server, the server declares the conformance classes
-        it implements and conforms to.
+        The URIs of all conformance classes supported by the server. To
+        support "generic" clients that want to access multiple OGC API
+        implementations, and not "just" a specific API / server, the server
+        declares the conformance classes it implements and conforms to.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/confClasses'
-          examples:
-            - conformsTo:
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/crawlable-catalog'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/searchable-catalog'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/local-resources-catalog'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-core'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-collection'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/record-api'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/sorting'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/cql'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/json'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/html'
-                - 'http://www.opengis.net/spec/ogcapi-records-1/1.0/conf/autodiscovery'
+            type: object
+            required:
+              - conformsTo
+            properties:
+              conformsTo:
+                type: array
+                items:
+                  type: string
         text/html:
           schema:
             type: string
@@ -909,19 +1199,28 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/catalogs'
+            allOf:
+              - $ref: '#/components/schemas/collections'
+              - type: object
+                properties:
+                  collections:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/catalog'
+                  linkTemplates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/linkTemplate'
         text/html:
           schema:
             type: string
     Catalog:
       description: |-
         Information about the record collection with id `collectionId`.
-
         The response contains a link to the items in the collection
         (path `/collections/{collectionId}/items`, link relation `items`)
         as well as key information about the collection. This information
         includes:
-
         * A local identifier for the collection that is unique for the +
           catalog;
         * A list of coordinate reference systems (CRS) in which geometries +
@@ -941,6 +1240,56 @@ components:
         text/html:
           schema:
             type: string
+    Records:
+      description:
+        The response is a document consisting of records in the collection.
+        The records included in the response are determined by the server
+        based on the query parameters of the request. To support access to
+        larger collections without overloading the client, the API supports
+        paged access with links to the next page, if more records are selected
+        that the page size.
+      
+        The `bbox` and `datetime` parameter can be used to select only a
+        subset of the records in the collection (the records that are in the
+        bounding box or time interval). The `bbox` parameter matches all records
+        in the collection that are not associated with a location, too. The
+        `datetime` parameter matches all records in the collection that are
+        not associated with a time stamp or interval, too.
+      
+        The `limit` parameter may be used to control the subset of the
+        selected records that should be returned in the response, the page size.
+        Each page may include information about the number of selected and
+        returned records (`numberMatched` and `numberReturned`) as well as
+        links to support paging (link relation `next`).
+      content:
+        application/geo+json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/featureCollectionGeoJSON'
+              - type: object
+                properties:
+                  features:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/recordGeoJSON'
+                  linkTemplates:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/linkTemplate'
+        text/html:
+          schema:
+            type: string
+    Record:
+      description:
+        Fetch the record with id `recordId` in the record collection
+        with id `collectionId`
+      content:
+        application/geo+json:
+          schema:
+            $ref: '#/components/schemas/recordGeoJSON'
+        text/html:
+          schema:
+            type: string
     Sortables:
       description:
         A list of properties that may be specified for sorting the response.
@@ -948,37 +1297,6 @@ components:
         application/json:
           schema:
             type: object
-        text/html:
-          schema:
-            type: string
-    Records:
-      description:
-        The response is a document consisting of records in the catalog.
-        The records included in the response are determined by the server
-        based on the query parameters of the request. To support access to
-        larger catalogs without overloading the client, the API supports
-        paged access with links to the next page, if more features are selected
-        that the page size.  The `limit` parameter may be used to control the
-        subset of the selected features that should be returned in the
-        response, the page size. Each page may include information about the
-        number of selected and returned records (`numberMatched` and
-        `numberReturned`) as well as links to support paging (link relation
-        `next`).
-      content:
-        application/geo+json:
-          schema:
-            $ref: '#/components/schemas/featureCollectionGeoJSON'
-        text/html:
-          schema:
-            type: string
-    Record:
-      description:
-        The response document consists of a specified record, with
-        identifier `recordId` from a catalog with identifier `catalogId`.
-      content:
-        application/geo+json:
-          schema:
-            $ref: '#/components/schemas/recordGeoJSON'
         text/html:
           schema:
             type: string
@@ -1000,18 +1318,18 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/exception"
+            $ref: '#/components/schemas/exception'
         text/html:
           schema:
             type: string
     NotFound:
-      description: 
-        The requested resource does not exist on the server. For example, a
-        path parameter had an incorrect value.
+      description:
+        The requested resource does not exist on the server. For example,
+        a path parameter had an incorrect value.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/exception"
+            $ref: '#/components/schemas/exception'
         text/html:
           schema:
             type: string

--- a/core/openapi/ogcapi-records-1-example-ref-buildingblocks-bundle.yaml
+++ b/core/openapi/ogcapi-records-1-example-ref-buildingblocks-bundle.yaml
@@ -61,9 +61,9 @@ paths:
       operationId: getLandingPage
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/LandingPage'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/LandingPage'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
   '/conformance':
     get:
       tags:
@@ -75,9 +75,9 @@ paths:
       operationId: getConformanceDeclaration
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ConformanceDeclaration'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ConformanceDeclaration'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
   '/collections':
     get:
       tags:
@@ -88,9 +88,9 @@ paths:
       operationId: getCollections
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/Catalogs'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/Catalogs'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
   '/collections/{catalogId}':
     get:
       tags:
@@ -102,14 +102,14 @@ paths:
         with id `catalogId`.
       operationId: describeCollection
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/Catalog'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/Catalog'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
   '/collections/{catalogId}/sortables':
     get:
       tags:
@@ -121,14 +121,14 @@ paths:
         response.
       operationId: getSortables
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/Sortables'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/Sortables'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
   '/collections/{catalogId}/items':
     get:
       tags:
@@ -144,24 +144,24 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getRecords
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/bbox'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/datetime'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/limit'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/q'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/type'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/externalId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/ids'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/sortby'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/bbox'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/datetime'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/limit'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/q'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/type'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/externalId'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/ids'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/sortby'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/Records'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/Records'
         '400':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/InvalidParameter'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/InvalidParameter'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
   '/collections/{catalogId}/items/{recordId}':
     get:
       tags:
@@ -174,12 +174,12 @@ paths:
         Use content negotiation to request HTML or GeoJSON.
       operationId: getRecord
       parameters:
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
-        - $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/parameters/recordId'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/catalogId'
+        - $ref: 'ogcapi-records-1-building-blocks.yaml#/components/parameters/recordId'
       responses:
         '200':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/Record'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/Record'
         '404':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/NotFound'
         '500':
-          $ref: 'https://raw.githubusercontent.com/opengeospatial/ogcapi-records/master/core/openapi/ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'
+          $ref: 'ogcapi-records-1-building-blocks.yaml#/components/responses/ServerError'

--- a/core/openapi/responses/Catalogs.yaml
+++ b/core/openapi/responses/Catalogs.yaml
@@ -11,11 +11,11 @@ content:
             collections:
               type: array
               items:
-                $ref: 'catalog.yaml'
+                $ref: '../schemas/catalog.yaml'
             linkTemplates:
               type: array
               items:
-                $ref: 'linkTemplate.yaml'
+                $ref: '../schemas/linkTemplate.yaml'
   text/html:
     schema:
       type: string

--- a/core/openapi/schemas/catalog.yaml
+++ b/core/openapi/schemas/catalog.yaml
@@ -1,16 +1,11 @@
 ---
 allOf:
+  - $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/collection.yaml'
   - $ref: 'recordCommonProperties.yaml'
   - type: object
     required:
-      - id
       - type
-      - links
     properties:
-      id:
-        description:
-          The identifier of the catalog.
-        type: string
       itemType:
         description:
           If this catalog is a homogenous collection
@@ -41,16 +36,12 @@ allOf:
         type: string
         enum:
           - Catalog
-      extent:
-        $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/extent.yaml'
-      crs:
-        description:
-          The list of supported coordinate reference systems.
+      conformsTo:
         type: array
+        description:
+          The extensions/conformance classes used in this record.
         items:
           type: string
-        default:
-          - http://www.opengis.net/def/crs/OGC/1.3/CRS84
       recordsArrayName:
         type: string
         default:
@@ -65,7 +56,7 @@ allOf:
       links:
         type: array
         items:
-          $ref: 'linkBase.yaml'
+          $ref: 'link.yaml'
       linkTemplates:
         type: array
         items:

--- a/core/openapi/schemas/contact.yaml
+++ b/core/openapi/schemas/contact.yaml
@@ -31,7 +31,7 @@ properties:
       Graphic identifying a contact. The link relation should be `icon`
       and the media type should be an image media type.
     allOf:
-      - $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml' 
+      - $ref: 'link.yaml' 
       - type: object
         required:
           - rel
@@ -106,7 +106,7 @@ properties:
     description: On-line information about the contact.
     items:
       allOf:
-        - $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/link.yaml'
+        - $ref: 'link.yaml'
         - type: object
           required:
             - type

--- a/core/openapi/schemas/link.yaml
+++ b/core/openapi/schemas/link.yaml
@@ -1,0 +1,11 @@
+---
+type: object
+allOf:
+  - $ref: 'linkBase.yaml'
+  - type: object
+    required:
+      - href
+    properties:
+      href:
+        type: string
+        format: uri

--- a/core/openapi/schemas/linkBase.yaml
+++ b/core/openapi/schemas/linkBase.yaml
@@ -4,30 +4,26 @@ properties:
   rel:
     type: string
     description: The type or semantics of the relation.
-    examples:
-      - "alternate"
+    example: "alternate"
   type:
     type: string
     description:
       A hint indicating what the media type of the
       result of dereferencing the link should be.
-    examples:
-      - "application/geo+json"
+    example: "application/geo+json"
   hreflang:
     type: string
     description:
       A hint indicating what the language of the
       result of dereferencing the link should be.
-    examples:
-      - "en"
+    example: "en"
   title:
     type: string
     description:
       Used to label the destination of a link
       such that it can be used as a human-readable
       identifier.
-    examples:
-      - "Trierer Strasse 70, 53115 Bonn"
+    example: "Trierer Strasse 70, 53115 Bonn"
   length:
     type: integer
   created:

--- a/core/openapi/schemas/linkTemplate.yaml
+++ b/core/openapi/schemas/linkTemplate.yaml
@@ -10,8 +10,7 @@ allOf:
         description:
           Supplies a resolvable URI to a remote resource
           (or resource fragment).
-        examples:
-          - "http://data.example.com/buildings/(building-id}"
+        example: "http://data.example.com/buildings/(building-id}"
       varBase:
         type: string
         description:

--- a/core/openapi/schemas/recordCommonProperties.yaml
+++ b/core/openapi/schemas/recordCommonProperties.yaml
@@ -1,12 +1,6 @@
 ---
 type: object
 properties:
-  conformsTo:
-    type: array
-    description:
-      The extensions/conformance classes used in this record.
-    items:
-      type: string
   created:
     type: string
     description:

--- a/core/openapi/schemas/recordGeoJSON.yaml
+++ b/core/openapi/schemas/recordGeoJSON.yaml
@@ -24,6 +24,12 @@ properties:
       - enum:
         - null
       - $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml'
+  conformsTo:
+    type: array
+    description:
+      The extensions/conformance classes used in this record.
+    items:
+      type: string
   properties:
     allOf:
       - $ref: 'recordCommonProperties.yaml'
@@ -32,7 +38,7 @@ properties:
   links:
     type: array
     items:
-      $ref: 'linkBase.yaml'
+      $ref: 'link.yaml'
   linkTemplates:
     type: array
     items:

--- a/core/openapi/schemas/recordJSON.yaml
+++ b/core/openapi/schemas/recordJSON.yaml
@@ -26,12 +26,18 @@ allOf:
           - enum:
             - null
           - $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/geometryGeoJSON.yaml'
+      conformsTo:
+        type: array
+        description:
+          The extensions/conformance classes used in this record.
+        items:
+          type: string
       links:
         description:
           A list of static links associated with this record.
         type: array
         items:
-          $ref: 'linkBase.yaml'
+          $ref: 'link.yaml'
       linkTemplates:
         description:
           A list of dynamic links associated with this record.


### PR DESCRIPTION
Closes #398 

This PR moves the conformsTo member to the top level of the GeoJSON encoding.  Not sure how but somewhere along the line it was incorrectly moves to the "properties" section.

This PR also undoes the changes from PR #396 since these changes cause validation errors using swagger-cli.
