### PR TITLE
Link schema does not allow CURIEs

### DIFF
--- a/core/openapi/schemas/link.yaml
+++ b/core/openapi/schemas/link.yaml
@@ -8,4 +8,3 @@ allOf:
     properties:
       href:
         type: string
-        format: uri


### PR DESCRIPTION
The current OpenAPI schema for links is too restrictive and does not allow CURIE values.
This PR removes the `uri` format, identical to the [schema as published in API Features spec](https://github.com/opengeospatial/ogcapi-features/blob/master/core/openapi/schemas/link.yaml).