### PR TITLE
Separate schema for recordCollectionGeoJSON

### DIFF
--- a/core/openapi/responses/Records.yaml
+++ b/core/openapi/responses/Records.yaml
@@ -22,18 +22,7 @@ description:
 content:
   application/geo+json:
     schema:
-      allOf:
-        - $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureCollectionGeoJSON.yaml'
-        - type: object
-          properties:
-            features:
-              type: array
-              items:
-                $ref: '../schemas/recordGeoJSON.yaml'
-            linkTemplates:
-              type: array
-              items:
-                $ref: '../schemas/linkTemplate.yaml'
+      $ref: '../schemas/recordCollectionGeoJSON.yaml'
   text/html:
     schema:
       type: string

--- a/core/openapi/schemas/recordCollectionGeoJSON.yaml
+++ b/core/openapi/schemas/recordCollectionGeoJSON.yaml
@@ -1,0 +1,12 @@
+allOf:
+  - $ref: 'https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/featureCollectionGeoJSON.yaml'
+  - type: object
+    properties:
+      features:
+        type: array
+        items:
+          $ref: 'recordGeoJSON.yaml'
+      linkTemplates:
+        type: array
+        items:
+          $ref: 'linkTemplate.yaml'


### PR DESCRIPTION
This PR separates the record collections schema from the response object. This allows the schema to be re-used independently from the response object. As far I can see, this seems to be more consistent with other responses/schemas.